### PR TITLE
README: tox is a dependency of tox-uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that you will get both the benefits (performance) or downsides (bugs) of uv
 Install `tox-uv` into the environment of your tox and it will replace virtualenv and pip for all runs:
 
 ```bash
-python -m pip install tox tox-uv
+python -m pip install tox-uv
 python -m tox r -e py312 # will use uv
 ```
 


### PR DESCRIPTION
No need to tell people to explicitly install tox, it's already dependency of tox-uv:

https://github.com/tox-dev/tox-uv/blob/bd93a99698a48d694937f5cec1cdfd5c55ab149e/pyproject.toml#L40-L43