### PR TITLE
Fix fail for package with '-' in name

### DIFF
--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -85,7 +85,7 @@ class UvInstaller(Pip):
                 groups["req"].append(str(arg))  # pragma: no cover
             elif isinstance(arg, (WheelPackage, SdistPackage, EditablePackage)):
                 groups["req"].extend(str(i) for i in arg.deps)
-                name = arg.path.name.split("-")[0]
+                name = "-".join(arg.path.name.split("-")[:-1])
                 groups["pkg"].append(f"{name}@{arg.path}")
             elif isinstance(arg, EditableLegacyPackage):
                 groups["req"].extend(str(i) for i in arg.deps)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def demo_pkg_inline(root: Path) -> Path:
     return root / "demo_pkg_inline"
 
 
+@pytest.fixture(scope="session")
+def demo_with_dash(root: Path) -> Path:
+    return root / "demo_with_dash"
+
+
 pytest_plugins = [
     "tox.pytest",
 ]

--- a/tests/demo_with_dash/build.py
+++ b/tests/demo_with_dash/build.py
@@ -1,0 +1,130 @@
+"""
+Please keep this file Python 2.7 compatible.
+See https://tox.readthedocs.io/en/rewrite/development.html#code-style-guide
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tarfile
+from pathlib import Path
+from textwrap import dedent
+from zipfile import ZipFile
+
+name = "demo-with-dash"
+pkg_name = name.replace("-", "_")
+
+version = "1.0.0"
+dist_info = f"{pkg_name}-{version}.dist-info"
+logic = f"{pkg_name}/__init__.py"
+plugin = f"{pkg_name}/example_plugin.py"
+entry_points = f"{dist_info}/entry_points.txt"
+metadata = f"{dist_info}/METADATA"
+wheel = f"{dist_info}/WHEEL"
+record = f"{dist_info}/RECORD"
+content = {
+    logic: f"def do():\n    print('greetings from {pkg_name}')",
+    plugin: """
+        try:
+            from tox.plugin import impl
+            from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
+            from tox.tox_env.register import ToxEnvRegister
+        except ImportError:
+            pass
+        else:
+            class ExampleVirtualEnvRunner(VirtualEnvRunner):
+                @staticmethod
+                def id() -> str:
+                    return "example"
+            @impl
+            def tox_register_tox_env(register: ToxEnvRegister) -> None:
+                register.add_run_env(ExampleVirtualEnvRunner)
+        """,
+}
+metadata_files = {
+    entry_points: f"""
+        [tox]
+        example = {name}.example_plugin""",
+    metadata: """
+        Metadata-Version: 2.1
+        Name: {}
+        Version: {}
+        Summary: UNKNOWN
+        Home-page: UNKNOWN
+        Author: UNKNOWN
+        Author-email: UNKNOWN
+        License: UNKNOWN
+        {}
+        Platform: UNKNOWN
+
+        UNKNOWN
+       """.format(
+        pkg_name,
+        version,
+        "\n        ".join(os.environ.get("METADATA_EXTRA", "").split("\n")),
+    ),
+    wheel: f"""
+        Wheel-Version: 1.0
+        Generator: {pkg_name}-{version}
+        Root-Is-Purelib: true
+        Tag: py{sys.version_info[0]}-none-any
+       """,
+    f"{dist_info}/top_level.txt": name,
+    record: f"""
+        {name}/__init__.py,,
+        {dist_info}/METADATA,,
+        {dist_info}/WHEEL,,
+        {dist_info}/top_level.txt,,
+        {dist_info}/RECORD,,
+       """,
+}
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict[str, str] | None = None,  # noqa: ARG001
+    metadata_directory: str | None = None,
+) -> str:
+    base_name = f"{pkg_name}-{version}-py{sys.version_info[0]}-none-any.whl"
+    path = Path(wheel_directory) / base_name
+    with ZipFile(str(path), "w") as zip_file_handler:
+        for arc_name, data in content.items():  # pragma: no branch
+            zip_file_handler.writestr(arc_name, dedent(data).strip())
+        if metadata_directory is not None:
+            for sub_directory, _, filenames in os.walk(metadata_directory):
+                for filename in filenames:
+                    zip_file_handler.write(
+                        str(Path(metadata_directory) / sub_directory / filename),
+                        str(Path(sub_directory) / filename),
+                    )
+        else:
+            for arc_name, data in metadata_files.items():
+                zip_file_handler.writestr(arc_name, dedent(data).strip())
+    print(f"created wheel {path}")  # noqa: T201
+    return base_name
+
+
+def get_requires_for_build_wheel(config_settings: dict[str, str] | None = None) -> list[str]:  # noqa: ARG001
+    return []  # pragma: no cover # only executed in non-host pythons
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: dict[str, str] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    return build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+def build_sdist(sdist_directory: str, config_settings: dict[str, str] | None = None) -> str:  # noqa: ARG001
+    result = f"{name}-{version}.tar.gz"  # pragma: win32 cover
+    with tarfile.open(str(Path(sdist_directory) / result), "w:gz") as tar:  # pragma: win32 cover
+        root = Path(__file__).parent  # pragma: win32 cover
+        tar.add(str(root / "build.py"), "build.py")  # pragma: win32 cover
+        tar.add(str(root / "pyproject.toml"), "pyproject.toml")  # pragma: win32 cover
+    return result  # pragma: win32 cover
+
+
+def get_requires_for_build_sdist(config_settings: dict[str, str] | None = None) -> list[str]:  # noqa: ARG001
+    return []  # pragma: no cover # only executed in non-host pythons

--- a/tests/demo_with_dash/pyproject.toml
+++ b/tests/demo_with_dash/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+build-backend = "build"
+requires = [
+]
+backend-path = [
+  ".",
+]
+
+[tool.black]
+line-length = 120

--- a/tests/test_tox_uv_package.py
+++ b/tests/test_tox_uv_package.py
@@ -30,6 +30,13 @@ def test_uv_package_editable(tox_project: ToxProjectCreator, package: str, demo_
     result.assert_success()
 
 
+@pytest.mark.parametrize("package", ["sdist", "wheel", "editable"])
+def test_uv_package_with_dash(tox_project: ToxProjectCreator, package: str, demo_with_dash: Path) -> None:
+    project = tox_project({"tox.ini": f"[testenv]\npackage={package}"}, base=demo_with_dash)
+    result = project.run()
+    result.assert_success()
+
+
 def test_uv_package_editable_legacy(tox_project: ToxProjectCreator, demo_pkg_setuptools: Path) -> None:
     ini = f"""
     [testenv]


### PR DESCRIPTION
When package contained '-' tox-uv failed to install it. The name was split and the first part was taken which caused that the rest of the name was missing.

Closes: https://github.com/tox-dev/tox-uv/issues/31