### PR TITLE
Ensure uv pip freeze is colorless

### DIFF
--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -29,7 +29,7 @@ class UvInstaller(Pip):
         super()._register_config()
         if self._with_list_deps:  # pragma: no branch
             conf = cast(ConfigDynamicDefinition[Command], self._env.conf._defined["list_dependencies_command"])  # noqa: SLF001
-            conf.default = Command([self.uv, "pip", "freeze"])
+            conf.default = Command([self.uv, "--color", "never", "pip", "freeze"])
 
     @property
     def uv(self) -> str:

--- a/tests/test_tox_uv_api.py
+++ b/tests/test_tox_uv_api.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tox.execute import ExecuteRequest
+    from tox.pytest import ToxProjectCreator
+
+
+def test_uv_list_dependencies_command(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[testenv]\npackage=skip"})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("--list-dependencies", "-vv")
+    result.assert_success()
+    request: ExecuteRequest = execute_calls.call_args[0][3]
+    assert request.cmd[1:] == ["--color", "never", "pip", "freeze"]


### PR DESCRIPTION
The 'uv pip freeze' command should automatically determine whether or not to provide coloring if the output is going to a terminal or TTY with support. This is not happening in this case.

Ensuring color is always disabled for this command is a good first step to work around this issue. Fixes #38.