### PR TITLE
Pass sys.executable to `uv venv` if it is the same version

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -113,7 +113,13 @@ class UvVenv(Python, ABC):
 
     def create_python_env(self) -> None:
         base = self.base_python.version_info
-        version_spec = f"{base.major}.{base.minor}" if base.minor else f"{base.major}"
+        version_spec = (
+            sys.executable
+            if (base.major, base.minor) == sys.version_info[:2]
+            else f"{base.major}.{base.minor}"
+            if base.minor
+            else f"{base.major}"
+        )
         cmd: list[str] = [self.uv, "venv", "-p", version_spec]
         if self.options.verbosity > 2:  # noqa: PLR2004
             cmd.append("-v")

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -4,7 +4,7 @@ import importlib.util
 import os
 import os.path
 import pathlib
-import subprocess
+import subprocess  # noqa: S404
 import sys
 from configparser import ConfigParser
 from typing import TYPE_CHECKING

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -104,10 +104,12 @@ def test_uv_env_python_not_in_path(tox_project: ToxProjectCreator) -> None:
     )
 
     # Make sure the Python interpreter can find our Tox module
+    tox_spec = importlib.util.find_spec("tox")
+    assert tox_spec is not None
     tox_lines = subprocess.check_output(
         [sys.executable, "-c", "import tox; print(tox.__file__);"], encoding="UTF-8", env=env
     ).splitlines()
-    assert tox_lines == [importlib.util.find_spec("tox").origin]
+    assert tox_lines == [tox_spec.origin]
 
     # Now use that Python interpreter to run Tox
     project = tox_project({"tox.ini": "[testenv]\npackage=skip\ncommands=python -c 'print(\"{env_python}\")'"})

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import importlib.util
+import os
+import os.path
+import pathlib
+import subprocess
 import sys
 from configparser import ConfigParser
 from typing import TYPE_CHECKING
@@ -86,3 +91,26 @@ def test_uv_env_site_package_dir(tox_project: ToxProjectCreator) -> None:
     else:  # pragma: win32 no cover
         path = str(env_dir / "lib" / f"python{ver.major}.{ver.minor}" / "site-packages")
     assert path in result.out
+
+
+def test_uv_env_python_not_in_path(tox_project: ToxProjectCreator) -> None:
+    # Make sure there is no pythonX.Y in the search path
+    ver = sys.version_info
+    exe_ext = ".exe" if sys.platform == "win32" else ""
+    python_exe = f"python{ver.major}.{ver.minor}{exe_ext}"
+    env = dict(os.environ)
+    env["PATH"] = os.path.pathsep.join(
+        path for path in env["PATH"].split(os.path.pathsep) if not (pathlib.Path(path) / python_exe).is_file()
+    )
+
+    # Make sure the Python interpreter can find our Tox module
+    tox_lines = subprocess.check_output(
+        [sys.executable, "-c", "import tox; print(tox.__file__);"], encoding="UTF-8", env=env
+    ).splitlines()
+    assert tox_lines == [importlib.util.find_spec("tox").origin]
+
+    # Now use that Python interpreter to run Tox
+    project = tox_project({"tox.ini": "[testenv]\npackage=skip\ncommands=python -c 'print(\"{env_python}\")'"})
+    tox_ini = project.path / "tox.ini"
+    assert tox_ini.is_file()
+    subprocess.check_call([sys.executable, "-m", "tox", "-c", tox_ini], env=env)


### PR DESCRIPTION
Hi,

Thanks a lot for writing and maintaining tox-uv, as well as for all your work in the Python ecosystem!

Now, I have a somewhat unusual setup: a vendor-specific Python interpreter that is not in the normal search path. Since I'd like to use tox-uv to test that my modules will also be compatible with that version, I have a virtual environment with tox and tox-uv (and, actually, also test-stages for the tox-stages utility); however, a stock installation of tox-uv within such a virtual environment passes "-p 3.8" to uv, and since python3.8 is not in the search path, that fails.

What do you think about this change that uses sys.executable if the major and minor Python version are the same as the currently running interpreter?

Thanks in advance, and keep up the great work!

G'luck,
Peter

PS. Yes, Python 3.8 is too old; still, it is what it is :)
