### PR TITLE
Drop use of `VIRTUAL_ENV=${Python_ROOT_DIR}` workaround

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,9 +98,7 @@ jobs:
         run: python -m pip install uv
       - name: Uninstall pip
         run: python -m pip uninstall pip -y
-      - name: Allow uv to use the global Python
-        run: echo "UV_SYSTEM_PYTHON=1" >> $GITHUB_ENV
       - name: Install self
-        run: uv pip install tox-uv@.
+        run: uv pip install --system tox-uv@.
       - name: run check for ${{ matrix.tox_env }}
         run: python -m tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,8 +98,8 @@ jobs:
         run: python -m pip install uv
       - name: Uninstall pip
         run: python -m pip uninstall pip -y
-      - name: Active uv for global env
-        run: echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
+      - name: Allow uv to use the global Python
+        run: echo "UV_SYSTEM_PYTHON=1" >> $GITHUB_ENV
       - name: Install self
         run: uv pip install tox-uv@.
       - name: run check for ${{ matrix.tox_env }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,8 @@ jobs:
           python-version: "3.12"
       - name: Install uv
         run: python -m pip install uv
-      - name: Active uv for global env
-        run: echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
       - name: Install build
-        run: uv pip install build[virtualenv]
+        run: uv pip install --system build[virtualenv]
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Hi! 

In the latest uv release, we no longer support this for using the system Python. You can see some more context at https://github.com/astral-sh/uv/issues/3765 and https://github.com/inventree/InvenTree/pull/7317.

