### PR TITLE
feat(UvInstaller): added KEEP_PIP environment, used to keep pip besid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ This is a uv specific feature that may be used as an alternative to frozen const
 intention is to validate the lower bounds of your dependencies during test executions.
 
 [resolution strategy]: https://github.com/astral-sh/uv/blob/0.1.20/README.md#resolution-strategy
+
+### KEEP_PIP
+This flag if set on a tox environment level, will keep pip beside uv. This is useful if your CI/CD pipeline relies on pip for some operations or not all your developers have tox-uv installed.
+
+- `yes` this will install the newest compatible pip version
+- `==24.1` this will install the specified pip version also `>=` or `<=` should be supported

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ intention is to validate the lower bounds of your dependencies during test execu
 [resolution strategy]: https://github.com/astral-sh/uv/blob/0.1.20/README.md#resolution-strategy
 
 ### KEEP_PIP
-This flag if set on a tox environment level, will keep pip beside uv. This is useful if your CI/CD pipeline relies on pip for some operations or not all your developers have tox-uv installed.
+This flag if set on environment level, will keep pip beside uv. This is useful if your CI/CD pipeline relies on pip for some operations or not all your developers have tox-uv installed.
 
 - `yes` this will install the newest compatible pip version
 - `==24.1` this will install the specified pip version also `>=` or `<=` should be supported

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -101,8 +101,6 @@ class UvInstaller(Pip):
             # the user wants to keep a special pip version
             if pip_version != "yes":
                 requirements_string += f"{pip_version}"
-            groups: dict[str, list[str]] = defaultdict(list)
-            groups["req"].append(requirements_string)
             self._execute_installer([requirements_string], of_type)
 
     def _install_list_of_deps(  # noqa: C901

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
@@ -92,6 +93,17 @@ class UvInstaller(Pip):
         else:  # pragma: no cover
             logging.warning("uv cannot install %r", arguments)  # pragma: no cover
             raise SystemExit(1)  # pragma: no cover
+
+        # Handle if the user wants to keep pip for compatibility with old ci/cd
+        if os.environ.get("KEEP_PIP"):
+            requirements_string = "pip"
+            pip_version = os.environ["KEEP_PIP"]
+            # the user wants to keep a special pip version
+            if pip_version != "yes":
+                requirements_string += f"{pip_version}"
+            groups: dict[str, list[str]] = defaultdict(list)
+            groups["req"].append(requirements_string)
+            self._execute_installer([requirements_string], of_type)
 
     def _install_list_of_deps(  # noqa: C901
         self,

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -100,6 +100,7 @@ def test_uv_install_with_resolution_strategy_custom_install_cmd(tox_project: Tox
 
     assert execute_calls.call_args[0][3].cmd[2:] == ["install", "tomli>=2.0.1", "--resolution", "lowest-direct"]
 
+
 def test_uv_install_no_keep_pip(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CI", "1")
     project = tox_project({"tox.ini": "[testenv]\ndeps = tomli\npackage=skip"})


### PR DESCRIPTION
This feature, can be used to keep pip inside the uv environment. Very helpful for old CI/CD pipelines, which should profit from the speed of uv, but also use some pip commands in them. Or if some developers have not switched to uv and keep pip