### PR TITLE
Python preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ This is a uv specific feature that may be used as an alternative to frozen const
 intention is to validate the lower bounds of your dependencies during test executions.
 
 [resolution strategy]: https://github.com/astral-sh/uv/blob/0.1.20/README.md#resolution-strategy
+
+### uv_python_preference
+
+This flag, set on a tox environement level, controls how uv select the Python
+interpreter.
+
+By default, uv will attempt to use Python versions found on the system and only
+download managed interpreters when necessary. However, It's possible to adjust
+uv's Python version selection preference with the
+[python-preference](https://docs.astral.sh/uv/python-versions/#adjusting-python-version-preferences)
+option.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ intention is to validate the lower bounds of your dependencies during test execu
 
 ### uv_python_preference
 
-This flag, set on a tox environement level, controls how uv select the Python
+This flag, set on a tox environment level, controls how uv select the Python
 interpreter.
 
 By default, uv will attempt to use Python versions found on the system and only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ optional-dependencies.test = [
   "pytest>=8.2.1",
   "pytest-cov>=5",
   "pytest-mock>=3.14",
-  "pytest-xdist>=3.6.1",
-  "xdoctest>=1.1.5",
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"
 urls.Documentation = "https://github.com/tox-dev/tox-uv#tox-uv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "importlib-resources>=6.4; python_version<'3.9'",
   "packaging>=24",
   "tox<5,>=4.15",
-  "typing-extensions>=4.12.2",
+  "typing-extensions>=4.12.2; python_version<'3.10'",
   "uv<1,>=0.2.5",
 ]
 optional-dependencies.test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "importlib-resources>=6.4; python_version<'3.9'",
   "packaging>=24",
   "tox<5,>=4.15",
+  "typing-extensions>=4.12.2",
   "uv<1,>=0.2.5",
 ]
 optional-dependencies.test = [
@@ -51,6 +52,8 @@ optional-dependencies.test = [
   "pytest>=8.2.1",
   "pytest-cov>=5",
   "pytest-mock>=3.14",
+  "pytest-xdist>=3.6.1",
+  "xdoctest>=1.1.5",
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"
 urls.Documentation = "https://github.com/tox-dev/tox-uv#tox-uv"

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -56,7 +56,7 @@ class UvVenv(Python, ABC):
         # makes mypy crash. The problem is probably on tox's typing side
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=cast(type[Optional[PythonPreference]], Optional[PythonPreference]),
+            of_type=cast(type, Optional[PythonPreference]),
             default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -50,7 +50,7 @@ class UvVenv(Python, ABC):
             desc="add seed packages to the created venv",
         )
         self.conf.add_config(
-            keys=["python_fetch"],
+            keys=["uv_python_fetch"],
             of_type=str,
             default="no",
             desc="Whether to automatically download Python when required [possible values: no, automatic, manual]",
@@ -59,7 +59,7 @@ class UvVenv(Python, ABC):
     def python_cache(self) -> dict[str, Any]:
         result = super().python_cache()
         result["seed"] = self.conf["uv_seed"]
-        result["python_fetch"] = self.conf["python_fetch"]
+        result["python_fetch"] = self.conf["uv_python_fetch"]
         result["venv"] = str(self.venv_dir.relative_to(self.env_dir))
         return result
 
@@ -165,8 +165,8 @@ class UvVenv(Python, ABC):
             cmd.append("-v")
         if self.conf["uv_seed"]:
             cmd.append("--seed")
-        if self.conf["python_fetch"] != "no":
-            cmd.extend(["--python-fetch", self.conf["python_fetch"]])
+        if self.conf["uv_python_fetch"] != "no":
+            cmd.extend(["--python-fetch", self.conf["uv_python_fetch"]])
         cmd.append(str(self.venv_dir))
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="venv", show=None)
         outcome.assert_success()

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -50,16 +50,22 @@ class UvVenv(Python, ABC):
             desc="add seed packages to the created venv",
         )
         self.conf.add_config(
-            keys=["uv_python_fetch"],
+            keys=["uv_python_preference"],
             of_type=str,
-            default="no",
-            desc="Whether to automatically download Python when required [possible values: no, automatic, manual]",
+            default="none",
+            desc=(
+                "Whether to prefer using Python installations that are already"
+                " present on the system, or those that are downloaded and"
+                " installed by uv [possible values: only-managed, installed,"
+                " managed, system, only-system, none]. Use none to use uv's"
+                " default."
+            ),
         )
 
     def python_cache(self) -> dict[str, Any]:
         result = super().python_cache()
         result["seed"] = self.conf["uv_seed"]
-        result["python_fetch"] = self.conf["uv_python_fetch"]
+        result["python_preference"] = self.conf["uv_python_preference"]
         result["venv"] = str(self.venv_dir.relative_to(self.env_dir))
         return result
 
@@ -165,8 +171,8 @@ class UvVenv(Python, ABC):
             cmd.append("-v")
         if self.conf["uv_seed"]:
             cmd.append("--seed")
-        if self.conf["uv_python_fetch"] != "no":
-            cmd.extend(["--python-fetch", self.conf["uv_python_fetch"]])
+        if self.conf["uv_python_preference"] != "none":
+            cmd.extend(["--python-preference", self.conf["uv_python_preference"]])
         cmd.append(str(self.venv_dir))
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="venv", show=None)
         outcome.assert_success()

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover (py38+)
 
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
     from tox.execute.api import Execute
     from tox.tox_env.api import ToxEnvCreateArgs
     from tox.tox_env.installer import Installer
+
+
+PythonPreference = Literal[
+    "only-managed", "installed", "managed", "system", "only-system"
+]
 
 
 class UvVenv(Python, ABC):
@@ -51,13 +56,13 @@ class UvVenv(Python, ABC):
         )
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=str,
-            default="none",
+            of_type=Optional[PythonPreference],
+            default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"
                 " present on the system, or those that are downloaded and"
                 " installed by uv [possible values: only-managed, installed,"
-                " managed, system, only-system, none]. Use none to use uv's"
+                " managed, system, only-system]. Use none to use uv's"
                 " default."
             ),
         )
@@ -171,7 +176,7 @@ class UvVenv(Python, ABC):
             cmd.append("-v")
         if self.conf["uv_seed"]:
             cmd.append("--seed")
-        if self.conf["uv_python_preference"] != "none":
+        if self.conf["uv_python_preference"]:
             cmd.extend(["--python-preference", self.conf["uv_python_preference"]])
         cmd.append(str(self.venv_dir))
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="venv", show=None)

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -43,12 +43,23 @@ class UvVenv(Python, ABC):
 
     def register_config(self) -> None:
         super().register_config()
-        desc = "add seed packages to the created venv"
-        self.conf.add_config(keys=["uv_seed"], of_type=bool, default=False, desc=desc)
+        self.conf.add_config(
+            keys=["uv_seed"],
+            of_type=bool,
+            default=False,
+            desc="add seed packages to the created venv",
+        )
+        self.conf.add_config(
+            keys=["python_fetch"],
+            of_type=str,
+            default="no",
+            desc="Whether to automatically download Python when required [possible values: no, automatic, manual]",
+        )
 
     def python_cache(self) -> dict[str, Any]:
         result = super().python_cache()
         result["seed"] = self.conf["uv_seed"]
+        result["python_fetch"] = self.conf["python_fetch"]
         result["venv"] = str(self.venv_dir.relative_to(self.env_dir))
         return result
 
@@ -154,6 +165,8 @@ class UvVenv(Python, ABC):
             cmd.append("-v")
         if self.conf["uv_seed"]:
             cmd.append("--seed")
+        if self.conf["python_fetch"] != "no":
+            cmd.extend(["--python-fetch", self.conf["python_fetch"]])
         cmd.append(str(self.venv_dir))
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="venv", show=None)
         outcome.assert_success()

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover (py38+)
 
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
@@ -54,7 +54,7 @@ class UvVenv(Python, ABC):
         )
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=Optional[PythonPreference],
+            of_type=Union[PythonPreference, None],
             default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover (py38+)
 
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from tox.tox_env.installer import Installer
 
 
-PythonPreference: TypeAlias = Literal["only-managed", "installed", "managed", "system", "only-system"]
+PythonPreference = Literal["only-managed", "installed", "managed", "system", "only-system"]
 
 
 class UvVenv(Python, ABC):

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -34,9 +34,7 @@ if TYPE_CHECKING:
     from tox.tox_env.installer import Installer
 
 
-PythonPreference = Literal[
-    "only-managed", "installed", "managed", "system", "only-system"
-]
+PythonPreference = Literal["only-managed", "installed", "managed", "system", "only-system"]
 
 
 class UvVenv(Python, ABC):

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -16,12 +16,13 @@ else:  # pragma: no cover (py38+)
 
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, Type, cast
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
 from tox.tox_env.errors import Skip
 from tox.tox_env.python.api import Python, PythonInfo, VersionInfo
+from typing_extensions import TypeAlias
 from uv import find_uv_bin
 from virtualenv import app_data
 from virtualenv.discovery import cached_py_info
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from tox.tox_env.installer import Installer
 
 
-PythonPreference = Literal["only-managed", "installed", "managed", "system", "only-system"]
+PythonPreference: TypeAlias = Literal["only-managed", "installed", "managed", "system", "only-system"]
 
 
 class UvVenv(Python, ABC):
@@ -57,7 +58,7 @@ class UvVenv(Python, ABC):
         # makes mypy crash. The problem is probably on tox's typing side
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=cast(type, Optional[PythonPreference]),
+            of_type=cast(Type[Optional[PythonPreference]], Optional[PythonPreference]),
             default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -22,7 +22,12 @@ from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
 from tox.tox_env.errors import Skip
 from tox.tox_env.python.api import Python, PythonInfo, VersionInfo
-from typing_extensions import TypeAlias
+
+if sys.version_info >= (3, 10):  # pragma: no cover (py310+)
+    from typing import TypeAlias
+else:  # pragma: no cover (<py310)
+    from typing_extensions import TypeAlias
+
 from uv import find_uv_bin
 from virtualenv import app_data
 from virtualenv.discovery import cached_py_info

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover (py38+)
 
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, cast
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from tox.tox_env.installer import Installer
 
 
-PythonPreference = Literal["only-managed", "installed", "managed", "system", "only-system"]
+PythonPreference: TypeAlias = Literal["only-managed", "installed", "managed", "system", "only-system"]
 
 
 class UvVenv(Python, ABC):
@@ -52,9 +52,11 @@ class UvVenv(Python, ABC):
             default=False,
             desc="add seed packages to the created venv",
         )
+        # The cast(...) might seems superfluous but removing it
+        # makes mypy crash. The problem is probably on tox's typing side
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=Union[PythonPreference, None],
+            of_type=cast(type[Optional[PythonPreference]], Optional[PythonPreference]),
             default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -154,12 +154,20 @@ def test_uv_env_python(tox_project: ToxProjectCreator) -> None:
     assert env_bin_dir in result.out
 
 
-def test_uv_env_python_preference(tox_project: ToxProjectCreator) -> None:
+@pytest.mark.parametrize(
+    "preference",
+    ["only-managed", "installed", "managed", "system", "only-system"],
+)
+def test_uv_env_python_preference(
+    tox_project: ToxProjectCreator,
+    *,
+    preference: str,
+) -> None:
     project = tox_project({
         "tox.ini": (
             "[testenv]\n"
             "package=skip\n"
-            "uv_python_preference=only-managed\n"
+            f"uv_python_preference={preference}\n"
             "commands=python -c 'print(\"{env_python}\")'"
         )
     })

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -155,16 +155,14 @@ def test_uv_env_python(tox_project: ToxProjectCreator) -> None:
 
 
 def test_uv_env_python_preference(tox_project: ToxProjectCreator) -> None:
-    project = tox_project(
-        {
-            "tox.ini": (
-                "[testenv]\n"
-                "package=skip\n"
-                "uv_python_preference=only-managed\n"
-                "commands=python -c 'print(\"{env_python}\")'"
-            )
-        }
-    )
+    project = tox_project({
+        "tox.ini": (
+            "[testenv]\n"
+            "package=skip\n"
+            "uv_python_preference=only-managed\n"
+            "commands=python -c 'print(\"{env_python}\")'"
+        )
+    })
     result = project.run("-vv")
     result.assert_success()
 

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -154,6 +154,25 @@ def test_uv_env_python(tox_project: ToxProjectCreator) -> None:
     assert env_bin_dir in result.out
 
 
+def test_uv_env_python_preference(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.ini": (
+                "[testenv]\n"
+                "package=skip\n"
+                "uv_python_preference=only-managed\n"
+                "commands=python -c 'print(\"{env_python}\")'"
+            )
+        }
+    )
+    result = project.run("-vv")
+    result.assert_success()
+
+    exe = "python.exe" if sys.platform == "win32" else "python"
+    env_bin_dir = str(project.path / ".tox" / "py" / ("Scripts" if sys.platform == "win32" else "bin") / exe)
+    assert env_bin_dir in result.out
+
+
 def test_uv_env_site_package_dir_run(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[testenv]\npackage=skip\ncommands=python -c 'print(\"{envsitepackagesdir}\")'"})
     result = project.run("-vv")


### PR DESCRIPTION
This PR enables the usage of the flag --python-preference to better control which Python interpreter is used.

See https://docs.astral.sh/uv/python-versions/#adjusting-python-version-preferences

It does so by exposing a `uv_python_preference` configuration field.

Note: this can be used to download missing Python interpreter. Use for example

```
[testenv]
uv_python_preference = only-managed
```