### PR TITLE
fix: discussion link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: true # default
 contact_links:
   - name: 🤷💻🤦 Discussions
-    url: https://github.com/tox-dev/tox/discussions
+    url: https://github.com/tox-dev/tox-uv/discussions
     about: |
       Ask typical Q&A here. Please note that we cannot give support about Python packaging in general, questions about structuring projects and so on.
   - name: 📝 PyPA Code of Conduct


### PR DESCRIPTION
Redirect to tox-uv's discussion instead of tox.

Fix #86 