### PR TITLE
Tests: In other_interpreter_exe, try python3 -> python3.Y

### DIFF
--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -62,12 +62,12 @@ def other_interpreter_exe() -> pathlib.Path:  # pragma: no cover
 
     exe = pathlib.Path(sys.executable)
     base_python: pathlib.Path | None = None
-    if exe.name == "python":
+    if exe.name in {"python", "python3"}:
         # python -> pythonX.Y
         ver = sys.version_info
         base_python = exe.with_name(f"python{ver.major}.{ver.minor}")
     elif exe.name[-1].isdigit():
-        # python X[.Y] -> python
+        # python X.Y -> python
         base_python = exe.with_name(exe.stem[:-1])
     elif exe.suffix == ".exe":
         # python.exe <-> pythonw.exe


### PR DESCRIPTION
The "python" executable exists only if "python3" exists, but "python3" can exist without "python".

This is at least the case in Fedora,
following https://peps.python.org/pep-0394/#for-python-runtime-distributors