### PR TITLE
Drop 3.8 and uv sync now works in verbose mode same way as pip

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,7 +24,6 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
           - type
           - dev
           - pkg_meta
@@ -37,7 +36,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install tox
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
       - name: Install Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        additional_dependencies: ["tomli>=2.0.1"]
+        additional_dependencies: ["tomli>=2.0.2"]
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: "1.4.1"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = "MIT"
 maintainers = [
   { name = "Bernát Gábor", email = "gaborjbernat@gmail.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -41,11 +40,10 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "importlib-resources>=6.4.5; python_version<'3.9'",
   "packaging>=24.1",
-  "tox<5,>=4.20",
+  "tox<5,>=4.21.2",
   "typing-extensions>=4.12.2; python_version<'3.10'",
-  "uv<1,>=0.4.12",
+  "uv<1,>=0.4.18",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",
@@ -74,7 +72,6 @@ version.source = "vcs"
 line-length = 120
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 format.preview = true
 format.docstring-code-line-length = 100
@@ -155,3 +152,6 @@ overrides = [
     "uv.*",
   ], ignore_missing_imports = true },
 ]
+
+[tool.uv]
+cache-keys = [ { file = "pyproject.toml" }, { git = true } ]

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from packaging.requirements import Requirement
 from packaging.utils import parse_sdist_filename, parse_wheel_filename

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Set, cast
+from typing import TYPE_CHECKING, cast
 
 from tox.execute.request import StdinSource
 from tox.tox_env.python.package import SdistPackage, WheelPackage
@@ -49,14 +49,16 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
     def _setup_env(self) -> None:
         super()._setup_env()
         cmd = ["uv", "sync", "--frozen"]
-        for extra in cast(Set[str], sorted(self.conf["extras"])):
+        for extra in cast(set[str], sorted(self.conf["extras"])):
             cmd.extend(("--extra", extra))
         if not self.conf["with_dev"]:
             cmd.append("--no-dev")
         install_pkg = getattr(self.options, "install_pkg", None)
         if install_pkg is not None:
             cmd.append("--no-install-project")
-        outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=False)
+        if self.options.verbosity > 2:  # noqa: PLR2004
+            cmd.append("-v")
+        outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=self.options.verbosity > 1)
         outcome.assert_success()
         if install_pkg is not None:
             path = Path(install_pkg)

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -8,7 +8,7 @@ from abc import ABC
 from functools import cached_property
 from pathlib import Path
 from platform import python_implementation
-from typing import TYPE_CHECKING, Any, Literal, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, Type, cast  # noqa: UP035
 
 from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.execute.request import StdinSource
@@ -25,10 +25,7 @@ if sys.version_info >= (3, 10):  # pragma: no cover (py310+)
 else:  # pragma: no cover (<py310)
     from typing_extensions import TypeAlias
 
-if sys.version_info >= (3, 9):  # pragma: no cover (py39+)
-    from importlib.resources import as_file, files
-else:  # pragma: no cover (py38+)
-    from importlib_resources import as_file, files
+from importlib.resources import as_file, files
 
 if TYPE_CHECKING:
     from tox.execute.api import Execute
@@ -62,7 +59,7 @@ class UvVenv(Python, ABC):
         # The cast(...) might seems superfluous but removing it makes mypy crash. The problem isy on tox typing side.
         self.conf.add_config(
             keys=["uv_python_preference"],
-            of_type=cast(Type[Optional[PythonPreference]], Optional[PythonPreference]),
+            of_type=cast(Type[Optional[PythonPreference]], Optional[PythonPreference]),  # noqa: UP006
             default=None,
             desc=(
                 "Whether to prefer using Python installations that are already"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ env_list =
     3.11
     3.10
     3.9
-    3.8
     type
     pkg_meta
 skip_missing_interpreters = true
@@ -38,7 +37,7 @@ commands =
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
 skip_install = true
 deps =
-    pre-commit-uv>=4.1.2
+    pre-commit-uv>=4.1.3
 commands =
     pre-commit run --all-files --show-diff-on-failure
 
@@ -56,7 +55,7 @@ skip_install = true
 deps =
     check-wheel-contents>=0.6
     twine>=5.1.1
-    uv>=0.4.12
+    uv>=0.4.18
 commands =
     uv build --sdist --wheel --out-dir {env_tmp_dir} .
     twine check {env_tmp_dir}{/}*


### PR DESCRIPTION
This means that if you pass one -v to tox we show its output, if you pass two of it we make uv sync verbose.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
