### PR TITLE
Document how to temporarily disable tox-uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Install `tox-uv` into the environment of your tox, and it will replace `virtuale
 uv tool install tox --with tox-uv # use uv to install
 tox --version # validate you are using the installed tox
 tox r -e py312 # will use uv
+tox --runner virtualenv r -e py312 # will use virtualenv+pip
 ```
 
 ## tox environment types provided


### PR DESCRIPTION
To run tox with plain virtualenv, I used to:

 1. uninstall tox-uv
 2. run tox
 3. install tox-uv

That seemed tedious, so I looked up the correct way. I think this information might be useful to others.