### PR TITLE
Fix `pypyNone` interpreter spec when major version unspecified

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -183,7 +183,12 @@ class UvVenv(Python, ABC):
             version_spec = sys.executable
         else:
             uv_imp = "" if (imp and imp == "cpython") else imp
-            version_spec = f"{uv_imp or ''}{base.major}.{base.minor}" if base.minor else f"{uv_imp or ''}{base.major}"
+            if not base.major:
+                version_spec = f"{uv_imp or ''}"
+            elif not base.minor:
+                version_spec = f"{uv_imp or ''}{base.major}"
+            else:
+                version_spec = f"{uv_imp or ''}{base.major}.{base.minor}"
 
         cmd: list[str] = [self.uv, "venv", "-p", version_spec, "--allow-existing"]
         if self.options.verbosity > 3:  # noqa: PLR2004


### PR DESCRIPTION
This resolves the following error that occurs when the tox environment is simply named `pypy`:

```
pypy: skipped because could not find python interpreter with spec(s): pypyNone
```

This was observed while testing [the uap-python project](https://github.com/ua-parser/uap-python/blob/3bd09b751a0a622b7f3ef8b977f10640d3d912ca/tox.ini#L3-L4).

It looks like a test case should be added to `test_tox_uv_venv.py`, but I had difficulty figuring out how to trigger the code branch. I would appreciate a pointer how to add a test case for this!

----

## Reproducer

### `tox.ini`

```ini
[tox]
env_list = pypy

[testenv]
skip_install = true
commands = python -V
```

### Output

```console
$ tox --version
4.23.2 from /home/kurt/.local/pipx/venvs/tox/lib/python3.13/site-packages/tox/__init__.py
registered plugins:
    tox-uv-1.16.0 at /home/kurt/.local/pipx/venvs/tox/lib/python3.13/site-packages/tox_uv/plugin.py with uv==0.5.6

$ tox
pypy: venv> /home/kurt/.local/pipx/venvs/tox/bin/uv venv -p pypyNone --allow-existing /home/kurt/dev/test/.tox/pypy
pypy: skipped because could not find python interpreter with spec(s): pypyNone
  pypy: SKIP (0.01 seconds)
  evaluation failed :( (0.13 seconds)
```