### PR TITLE
Prevent user tox config from affecting tox-uv test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(autouse=True)
+def mock_settings_env_vars() -> Generator[None, None, None]:
+    """Isolated testing from user's environment."""
+    with mock.patch.dict(os.environ, {"TOX_USER_CONFIG_FILE": os.devnull}):
+        yield
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes: #130
