### PR TITLE
Use python version in lock runner

### DIFF
--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -79,6 +79,8 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         for group in sorted(self.conf["dependency_groups"]):
             cmd.extend(("--group", group))
         cmd.extend(self.conf["uv_sync_flags"])
+        cmd.extend(("-p", self.env_version_spec()))
+
         show = self.options.verbosity > 2  # noqa: PLR2004
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=show)
         outcome.assert_success()

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -197,21 +197,7 @@ class UvVenv(Python, ABC):
         return env
 
     def create_python_env(self) -> None:
-        base = self.base_python.version_info
-        imp = self.base_python.impl_lower
-        executable = self.base_python.extra.get("executable")
-        if executable:
-            version_spec = executable
-        elif (base.major, base.minor) == sys.version_info[:2] and (sys.implementation.name.lower() == imp):
-            version_spec = sys.executable
-        else:
-            uv_imp = imp or ""
-            if not base.major:
-                version_spec = uv_imp
-            elif not base.minor:
-                version_spec = f"{uv_imp}{base.major}"
-            else:
-                version_spec = f"{uv_imp}{base.major}.{base.minor}"
+        version_spec = self.env_version_spec()
 
         cmd: list[str] = [self.uv, "venv", "-p", version_spec, "--allow-existing"]
         if self.options.verbosity > 3:  # noqa: PLR2004
@@ -258,6 +244,24 @@ class UvVenv(Python, ABC):
             py = self._py_info
             impl = "pypy" if py.implementation == "pypy" else "python"
             return self.venv_dir / "lib" / f"{impl}{py.version_dot}" / "site-packages"
+
+    def env_version_spec(self) -> str:
+        base = self.base_python.version_info
+        imp = self.base_python.impl_lower
+        executable = self.base_python.extra.get("executable")
+        if executable:
+            version_spec = executable
+        elif (base.major, base.minor) == sys.version_info[:2] and (sys.implementation.name.lower() == imp):
+            version_spec = sys.executable
+        else:
+            uv_imp = imp or ""
+            if not base.major:
+                version_spec = uv_imp
+            elif not base.minor:
+                version_spec = f"{uv_imp}{base.major}"
+            else:
+                version_spec = f"{uv_imp}{base.major}.{base.minor}"
+        return version_spec
 
     @cached_property
     def _py_info(self) -> PythonInfo:  # pragma: win32 no cover

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -250,13 +250,13 @@ class UvVenv(Python, ABC):
         imp = self.base_python.impl_lower
         executable = self.base_python.extra.get("executable")
         if executable:
-            version_spec = executable
+            version_spec = str(executable)
         elif (base.major, base.minor) == sys.version_info[:2] and (sys.implementation.name.lower() == imp):
             version_spec = sys.executable
         else:
             uv_imp = imp or ""
             if not base.major:
-                version_spec = uv_imp
+                version_spec = f"{uv_imp}"
             elif not base.minor:
                 version_spec = f"{uv_imp}{base.major}"
             else:

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -58,6 +58,8 @@ def test_uv_lock_list_dependencies_command(tox_project: ToxProjectCreator) -> No
                 "type",
                 "--no-dev",
                 "-v",
+                "-p",
+                sys.executable,
             ],
         ),
         ("py", "freeze", [uv, "--color", "never", "pip", "freeze"]),
@@ -118,6 +120,8 @@ def test_uv_lock_command(tox_project: ToxProjectCreator, verbose: str) -> None:
                 "type",
                 "--no-dev",
                 *v_args,
+                "-p",
+                sys.executable,
             ],
         ),
         ("py", "commands[0]", ["python", "hello"]),
@@ -157,7 +161,7 @@ def test_uv_lock_with_dev(tox_project: ToxProjectCreator) -> None:
                 str(project.path / ".tox" / "py"),
             ],
         ),
-        ("py", "uv-sync", ["uv", "sync", "--frozen", "--python-preference", "system", "-v"]),
+        ("py", "uv-sync", ["uv", "sync", "--frozen", "--python-preference", "system", "-v", "-p", sys.executable]),
     ]
     assert calls == expected
 
@@ -203,7 +207,18 @@ def test_uv_lock_with_install_pkg(tox_project: ToxProjectCreator, name: str) -> 
         (
             "py",
             "uv-sync",
-            ["uv", "sync", "--frozen", "--python-preference", "system", "--no-dev", "--no-install-project", "-v"],
+            [
+                "uv",
+                "sync",
+                "--frozen",
+                "--python-preference",
+                "system",
+                "--no-dev",
+                "--no-install-project",
+                "-v",
+                "-p",
+                sys.executable,
+            ],
         ),
         (
             "py",
@@ -249,7 +264,17 @@ def test_uv_sync_extra_flags(tox_project: ToxProjectCreator) -> None:
         (
             "py",
             "uv-sync",
-            ["uv", "sync", "--frozen", "--python-preference", "system", "--no-editable", "--inexact"],
+            [
+                "uv",
+                "sync",
+                "--frozen",
+                "--python-preference",
+                "system",
+                "--no-editable",
+                "--inexact",
+                "-p",
+                sys.executable,
+            ],
         ),
         ("py", "commands[0]", ["python", "hello"]),
     ]
@@ -291,7 +316,17 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
         (
             "py",
             "uv-sync",
-            ["uv", "sync", "--frozen", "--python-preference", "system", "--no-editable", "--inexact"],
+            [
+                "uv",
+                "sync",
+                "--frozen",
+                "--python-preference",
+                "system",
+                "--no-editable",
+                "--inexact",
+                "-p",
+                sys.executable,
+            ],
         ),
         ("py", "commands[0]", ["python", "hello"]),
     ]
@@ -333,7 +368,19 @@ def test_uv_sync_dependency_groups(tox_project: ToxProjectCreator) -> None:
         (
             "py",
             "uv-sync",
-            ["uv", "sync", "--frozen", "--python-preference", "system", "--group", "test", "--group", "type"],
+            [
+                "uv",
+                "sync",
+                "--frozen",
+                "--python-preference",
+                "system",
+                "--group",
+                "test",
+                "--group",
+                "type",
+                "-p",
+                sys.executable,
+            ],
         ),
         ("py", "commands[0]", ["python", "hello"]),
     ]
@@ -384,7 +431,18 @@ def test_uv_sync_uv_python_preference(
         (
             "py",
             "uv-sync",
-            ["uv", "sync", "--frozen", *injected, "--group", "test", "--group", "type"],
+            [
+                "uv",
+                "sync",
+                "--frozen",
+                *injected,
+                "--group",
+                "test",
+                "--group",
+                "type",
+                "-p",
+                sys.executable,
+            ],
         ),
         ("py", "commands[0]", ["python", "hello"]),
     ]


### PR DESCRIPTION
### Summary

This PR addresses an issue with `uv-venv-lock-runner`, in which the Python version in the created environment gets overwritten with whatever `uv` considers to be the "default" for the project, rather than the version specified in the tox definition. As the fix is straightforward, I opted to create a PR directly rather than reporting an issue.

### Issue addressed
Under the following tox config,
```
[tox]
envlist =
  py{311,312}

[testenv]
runner = uv-venv-lock-runner
set_env =
  py311: EXPECTED_MINOR_VERSION=11
  py312: EXPECTED_MINOR_VERSION=12
commands =
  python assert_correct_version.py
allowlist_externals =
  python
```

```
# assert_correct_version.py
import sys
import os

if __name__ == "__main__":
    assert os.getenv("EXPECTED_MINOR_VERSION") == str(sys.version_info[1])
```
on a system with Python versions managed by pyenv and 3.11 set as default, using latest (1.19.0) tox-uv (on uv 0.5.21), I nondeterministically get *either*
1) An assertion failure under `py312` (i.e., non-system-default version), indicating that the test is being run under the incorrect Python version, *or*
2) The following tox internal error (note the paths in the stack trace referencing Python 3.11, rather than the expected 3.12)
```
py312: internal error
Traceback (most recent call last):
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/session/cmd/run/single.py", line 47, in _evaluate
    tox_env.setup()
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/tox_env/api.py", line 250, in setup
    self._setup_env()
  File "/Users/evanlloyd/tox-uv/src/tox_uv/_run_lock.py", line 83, in _setup_env
    outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=show)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/tox_env/api.py", line 389, in execute
    with self.execute_async(cmd, stdin, show, cwd, run_id, executor) as status:
  File "/Users/evanlloyd/.pyenv/versions/3.11.5/lib/python3.11/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/tox_env/api.py", line 443, in execute_async
    self._log_execute(request, execute_status)
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/tox_env/api.py", line 449, in _log_execute
    self._write_execute_log(self.name, self.env_log_dir / f"{self._log_id}-{request.run_id}.log", request, status)
  File "/Users/evanlloyd/.local/share/uv/tools/tox/lib/python3.11/site-packages/tox/tox_env/api.py", line 453, in _write_execute_log
    with log_file.open("wt", encoding="utf-8") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/evanlloyd/.pyenv/versions/3.11.5/lib/python3.11/pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/evanlloyd/toxuv-test/.tox/py312/log/2-uv-sync.log'
```

### Proposed fix
I added the `-p` option to explicitly choose a python version to be used by `tox sync` in `uv-venv-lock-runner`. Since the logic is identical to that used when creating the environment with `uv venv`, I consolidated it into a new function `UvVenv#env_version_spec`. I updated unit tests accordingly; all tests are green locally, and the reproducing example now behaves as expected.
