### PR TITLE
Allow skipping uv sync for lock runner via CLI flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "packaging>=24.2",
   "tox>=4.24.1,<5",
   "typing-extensions>=4.12.2; python_version<'3.10'",
-  "uv>=0.5.22,<1",
+  "uv>=0.5.27,<1",
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"
 urls.Documentation = "https://github.com/tox-dev/tox-uv#tox-uv"
@@ -62,14 +62,14 @@ dev = [
 test = [
   "covdefaults>=2.3",
   "devpi-process>=1.0.2",
-  "diff-cover>=9.2.1",
+  "diff-cover>=9.2.2",
   "pytest>=8.3.4",
   "pytest-cov>=6",
   "pytest-mock>=3.14",
 ]
 type = [ "mypy==1.14.1", { include-group = "test" } ]
 lint = [ "pre-commit-uv>=4.1.4" ]
-pkg-meta = [ "check-wheel-contents>=0.6.1", "twine>=6.1", "uv>=0.5.22" ]
+pkg-meta = [ "check-wheel-contents>=0.6.1", "twine>=6.1", "uv>=0.5.27" ]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/tox_uv/version.py"

--- a/src/tox_uv/plugin.py
+++ b/src/tox_uv/plugin.py
@@ -12,6 +12,7 @@ from ._run import UvVenvRunner
 from ._run_lock import UvVenvLockRunner
 
 if TYPE_CHECKING:
+    from tox.config.cli.parser import ToxParser
     from tox.tox_env.register import ToxEnvRegister
 
 
@@ -22,6 +23,17 @@ def tox_register_tox_env(register: ToxEnvRegister) -> None:
     register.add_package_env(UvVenvPep517Packager)
     register.add_package_env(UvVenvCmdBuilder)
     register._default_run_env = UvVenvRunner.id()  # noqa: SLF001
+
+
+@impl
+def tox_add_option(parser: ToxParser) -> None:
+    for key in ("run", "exec"):
+        parser.handlers[key][0].add_argument(
+            "--skip-uv-sync",
+            dest="skip_uv_sync",
+            help="skip uv sync (lock mode only)",
+            action="store_true",
+        )
 
 
 def tox_append_version_info() -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4.24.1
-    tox-uv>=1.20
+    tox-uv>=1.21.1
 env_list =
     fix
     3.13


### PR DESCRIPTION
Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
