### PR TITLE
Use --locked instead of --frozen for uv sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: ruff
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.5.0"
+    rev: "v3.5.1"
     hooks:
       - id: prettier
         args: ["--print-width=120", "--prose-wrap=always"]

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -78,7 +78,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             cmd = [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
             ]
             if self.conf["uv_python_preference"] != "none":
                 cmd.extend(("--python-preference", self.conf["uv_python_preference"]))

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -50,7 +50,7 @@ def test_uv_lock_list_dependencies_command(tox_project: ToxProjectCreator) -> No
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--extra",
@@ -112,7 +112,7 @@ def test_uv_lock_command(tox_project: ToxProjectCreator, verbose: str) -> None:
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--extra",
@@ -162,7 +162,7 @@ def test_uv_lock_with_default_groups(tox_project: ToxProjectCreator) -> None:
                 str(project.path / ".tox" / "py"),
             ],
         ),
-        ("py", "uv-sync", ["uv", "sync", "--frozen", "--python-preference", "system", "-v", "-p", sys.executable]),
+        ("py", "uv-sync", ["uv", "sync", "--locked", "--python-preference", "system", "-v", "-p", sys.executable]),
     ]
     assert calls == expected
 
@@ -212,7 +212,7 @@ def test_uv_lock_with_install_pkg(tox_project: ToxProjectCreator, name: str) -> 
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-install-project",
@@ -269,7 +269,7 @@ def test_uv_sync_extra_flags(tox_project: ToxProjectCreator) -> None:
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-editable",
@@ -322,7 +322,7 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-editable",
@@ -375,7 +375,7 @@ def test_uv_sync_dependency_groups(tox_project: ToxProjectCreator) -> None:
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-default-groups",
@@ -439,7 +439,7 @@ def test_uv_sync_uv_python_preference(
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 *injected,
                 "--no-default-groups",
                 "--group",
@@ -532,7 +532,7 @@ def test_uv_package_wheel(tox_project: ToxProjectCreator, monkeypatch: pytest.Mo
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-editable",
@@ -599,7 +599,7 @@ def test_skip_uv_package_skip(tox_project: ToxProjectCreator, monkeypatch: pytes
             [
                 "uv",
                 "sync",
-                "--frozen",
+                "--locked",
                 "--python-preference",
                 "system",
                 "--no-install-project",


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/11530#issuecomment-2660715025, we should fail if the `pyproject.toml` has been updated without regenerating the lock file, rather than ignore the change.