### PR TITLE
Prevent installation failure with custom install_package using pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ lint.ignore = [
   "D301",   #  Use `r"""` if any backslashes in a docstring
   "D401",   # First line of docstring should be in imperative mood
   "DOC201", # no support for sphinx
+  "DOC501", # no support for sphinx https://github.com/astral-sh/ruff/issues/12520
   "ISC001", # Conflict with formatter
   "S104",   # Possible binding to all interface
 ]

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -36,6 +36,29 @@ def test_uv_install_with_pre(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
 
+def test_uv_install_with_pre_custom_install_cmd_using_original_pip(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+    [testenv]
+    deps = tomli
+    pip_pre = true
+    package = skip
+    uv_seed = true
+    commands = python -c 'import tomli'
+
+    [testenv:a]
+
+    [testenv:b]
+    install_command = python3 -m pip install {packages}
+
+    [testenv:c]
+    install_command = uv pip install {packages}
+    """
+    })
+    result = project.run("r", "-v", "-e", "a,b,c")
+    result.assert_success()
+
+
 def test_uv_install_with_pre_custom_install_cmd(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "tox.ini": """


### PR DESCRIPTION
As some users might still use install_package and point to original pip, we want to use correct arguments names to this one.
