### PR TITLE
Adopt more modern ruff pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,14 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.13"
+    rev: "v0.12.0"
     hooks:
       - id: ruff-format
-      - id: ruff
-        args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
+        alias: ruff
+        args: ["--exit-non-zero-on-format"]
+      - id: ruff-check
+        alias: ruff
+        args: ["--exit-non-zero-on-fix"]
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: "v3.5.3"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ version.source = "vcs"
 
 [tool.ruff]
 line-length = 120
+fix = true
+unsafe-fixes = true
 format.preview = true
 format.docstring-code-line-length = 100
 format.docstring-code-format = true


### PR DESCRIPTION
- Avoids using the legacy ruff command and uses the two current hooks.
- Moves options to pyproject.toml to make external ruff calls in sync
  with pre-commit ones
- Adds 'ruff' alias, so users can easily call both hooks with:
  pre-commit run -a ruff
- Updates ruff hook version
