### PR TITLE
Allow use of uv installed outside current python environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ lint.ignore = [
   "D301",   #  Use `r"""` if any backslashes in a docstring
   "D401",   # First line of docstring should be in imperative mood
   "DOC201", # no support for sphinx
+  "DOC501", # no support for sphinx https://github.com/astral-sh/ruff/issues/12520
   "ISC001", # Conflict with formatter
   "S104",   # Possible binding to all interface
 ]

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -15,7 +15,8 @@ from tox.tox_env.errors import Fail, Recreate
 from tox.tox_env.python.package import EditableLegacyPackage, EditablePackage, SdistPackage, WheelPackage
 from tox.tox_env.python.pip.pip_install import Pip
 from tox.tox_env.python.pip.req_file import PythonDeps
-from uv import find_uv_bin
+
+from tox_uv._util import find_uv_bin
 
 from ._package_types import UvEditablePackage, UvPackage
 

--- a/src/tox_uv/_util.py
+++ b/src/tox_uv/_util.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import shutil
+import sysconfig
+
+# presence of 'uv' package is not required for use of uv as uv can be installed
+# as a standalone tool and still work fine. Also if uv is inside a virtualenv
+# importing might make its internal uv.find_uv_bin return an exception even if
+# we might have a working uv executable.
+
+
+def find_uv_bin() -> str:
+    """Return the uv binary path.
+
+    :raises FileNotFoundError: if uv is not found.
+    """
+
+    try:
+        import uv  # noqa: PLC0415
+
+        path = uv.find_uv_bin()
+    except (ImportError, FileNotFoundError):  # pragma: no cover
+        uv_exe = "uv" + sysconfig.get_config_var("EXE")
+        path = shutil.which(uv_exe)
+        if not path:
+            # pylint: disable=raise-missing-from
+            raise FileNotFoundError(uv_exe)  # noqa: B904
+    return path

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -20,8 +20,9 @@ from tox.execute.request import StdinSource
 from tox.tox_env.errors import Skip
 from tox.tox_env.python.api import Python, PythonInfo, VersionInfo
 from tox.tox_env.python.virtual_env.api import VirtualEnv
-from uv import find_uv_bin
 from virtualenv.discovery.py_spec import PythonSpec
+
+from tox_uv._util import find_uv_bin
 
 from ._installer import UvInstaller
 

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -4,7 +4,8 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
-from uv import find_uv_bin
+
+from tox_uv._util import find_uv_bin
 
 if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator


### PR DESCRIPTION
- Presence of 'uv' python module is not required for use of uv.
- `uv` can be installed as a standalone tool and still work fine.
- Avoids https://github.com/astral-sh/uv/issues/10194 bug with some virtualenvs