### PR TITLE
Enable minimal testing with windows and macOS

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     tags-ignore: ["**"]
   pull_request:
+  pull_request_target:
   schedule:
     - cron: "0 8 * * *"
 
@@ -14,7 +15,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    name: ${{ matrix.env }}${{ matrix.suffix || ''}}
     strategy:
       fail-fast: false
       matrix:
@@ -28,6 +30,17 @@ jobs:
           - type
           - dev
           - pkg_meta
+        os:
+          - ubuntu-latest
+        suffix:
+          - ""
+        include:
+          - env: "3.13"
+            os: windows-latest
+            suffix: -windows
+          - env: "3.13"
+            os: macos-latest
+            suffix: -macos
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,10 +58,12 @@ jobs:
       - name: Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
         env:
+          FORCE_COLOR: "1"
           UV_PYTHON_PREFERENCE: "only-managed"
       - name: Run test suite
         run: tox run --skip-pkg-install -e ${{ matrix.env }}
         env:
+          FORCE_COLOR: "1"
           PYTEST_ADDOPTS: "-vv --durations=20"
           DIFF_AGAINST: HEAD
           UV_PYTHON_PREFERENCE: "only-managed"

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -135,7 +135,7 @@ class UvVenv(Python, ABC):
                     free_threaded=sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
                 )
             base_path = Path(base)
-            if base_path.is_absolute():
+            if base_path.is_absolute():  # pragma: win32 no cover
                 info = VirtualEnv.get_virtualenv_py_info(base_path)
                 return PythonInfo(
                     implementation=info.implementation,
@@ -173,7 +173,7 @@ class UvVenv(Python, ABC):
         :param path: the path investigated
         :return: the found spec
         """
-        return VirtualEnv.python_spec_for_path(path)
+        return VirtualEnv.python_spec_for_path(path)  # pragma: win32 no cover
 
     @property
     def uv(self) -> str:
@@ -247,10 +247,9 @@ class UvVenv(Python, ABC):
         suffix = ".exe" if sys.platform == "win32" else ""
         return self.env_bin_dir() / f"python{suffix}"
 
-    def env_site_package_dir(self) -> Path:
+    def env_site_package_dir(self) -> Path:  # pragma: win32 no cover
         if sys.platform == "win32":  # pragma: win32 cover
             return self.venv_dir / "Lib" / "site-packages"
-        # pragma: win32 no cover
         py = self._py_info
         impl = "pypy" if py.implementation == "pypy" else "python"
         return self.venv_dir / "lib" / f"{impl}{py.version_dot}" / "site-packages"
@@ -261,7 +260,7 @@ class UvVenv(Python, ABC):
         executable = self.base_python.extra.get("executable")
         architecture = self.base_python.extra.get("architecture")
         free_threaded = self.base_python.free_threaded
-        if executable:
+        if executable:  # pragma: win32 no cover
             version_spec = str(executable)
         elif (
             architecture is None
@@ -273,7 +272,7 @@ class UvVenv(Python, ABC):
         else:
             uv_imp = imp or ""
             free_threaded_tag = "+freethreaded" if free_threaded else ""
-            if not base.major:
+            if not base.major:  # pragma: win32 no cover
                 version_spec = f"{uv_imp}"
             elif not base.minor:
                 version_spec = f"{uv_imp}{base.major}{free_threaded_tag}"

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -99,6 +99,10 @@ def test_uv_venv_spec_major_only(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Bug https://github.com/tox-dev/tox-uv/issues/193 https://github.com/astral-sh/uv/issues/14239",
+)
 @pytest.mark.parametrize(
     ("pypy", "expected_uv_pypy"),
     [
@@ -133,7 +137,7 @@ def test_uv_venv_spec_pypy(
     project = tox_project({"tox.ini": f"[tox]\nenv_list = {pypy}"})
     try:
         result = project.run("config", "-vv")
-    except tox.tox_env.errors.Skip:
+    except tox.tox_env.errors.Skip:  # pragma: win32 no cover
         stdout, _ = capfd.readouterr()
     else:  # pragma: no cover (PyPy might not be available on the system)
         stdout = result.out
@@ -208,15 +212,25 @@ def other_interpreter_exe() -> pathlib.Path:  # pragma: no cover
     return base_python
 
 
-def test_uv_venv_spec_abs_path(tox_project: ToxProjectCreator, other_interpreter_exe: pathlib.Path) -> None:
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Bug https://github.com/tox-dev/tox-uv/issues/193 https://github.com/astral-sh/uv/issues/14239",
+)
+def test_uv_venv_spec_abs_path(
+    tox_project: ToxProjectCreator, other_interpreter_exe: pathlib.Path
+) -> None:  # pragma: win32 no cover
     project = tox_project({"tox.ini": f"[testenv]\npackage=skip\nbase_python={other_interpreter_exe}"})
     result = project.run("-vv")
     result.assert_success()
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Bug https://github.com/tox-dev/tox-uv/issues/193 https://github.com/astral-sh/uv/issues/14239",
+)
 def test_uv_venv_spec_abs_path_conflict_ver(
     tox_project: ToxProjectCreator, other_interpreter_exe: pathlib.Path
-) -> None:
+) -> None:  # pragma: win32 no cover
     # py27 is long gone, but still matches the testenv capture regex, so we know it will fail
     project = tox_project({"tox.ini": f"[testenv:py27]\npackage=skip\nbase_python={other_interpreter_exe}"})
     result = project.run("-vv", "-e", "py27")
@@ -224,9 +238,13 @@ def test_uv_venv_spec_abs_path_conflict_ver(
     assert f"failed with env name py27 conflicting with base python {other_interpreter_exe}" in result.out
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Bug https://github.com/tox-dev/tox-uv/issues/193 https://github.com/astral-sh/uv/issues/14239",
+)
 def test_uv_venv_spec_abs_path_conflict_impl(
     tox_project: ToxProjectCreator, other_interpreter_exe: pathlib.Path
-) -> None:
+) -> None:  # pragma: win32 no cover
     env = "pypy" if platform.python_implementation() == "CPython" else "cpython"
     project = tox_project({"tox.ini": f"[testenv:{env}]\npackage=skip\nbase_python={other_interpreter_exe}"})
     result = project.run("-vv", "-e", env)


### PR DESCRIPTION
Due to the specific nature of how uv works, some minimal testing on Windows and MacOS would be needed.

Related: #193 #183
Related: https://github.com/astral-sh/uv/issues/14239
