### PR TITLE
Support skip_missing_interpreters on uv==0.8.0 (#222)

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -221,7 +221,7 @@ class UvVenv(Python, ABC):
         cmd.append(str(self.venv_dir))
         outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="venv", show=None)
 
-        if self.core["skip_missing_interpreters"] and outcome.exit_code == 1:
+        if self.core["skip_missing_interpreters"] and outcome.exit_code in {1, 2}:
             msg = f"could not find python interpreter with spec(s): {version_spec}"
             raise Skip(msg)
 

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -244,12 +244,23 @@ def test_uv_venv_na(tox_project: ToxProjectCreator) -> None:
     result.assert_failed(code=-1)
 
 
+def test_uv_venv_na_uv_072(tox_project: ToxProjectCreator) -> None:
+    # Test uv==0.7.2
+    # skip_missing_interpreters is true by default
+    project = tox_project({"tox.ini": "[testenv]\npackage=skip\nbase_python=1.0\nrequires=uv==0.7.2"})
+    result = project.run("-vv")
+
+    # When a Python interpreter is missing in a pytest environment, project.run
+    # return code is equal to -1
+    result.assert_failed(code=-1)
+
+
 def test_uv_venv_skip_missing_interpreters_fail(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "tox.ini": "[tox]\nskip_missing_interpreters=false\n[testenv]\npackage=skip\nbase_python=1.0"
     })
     result = project.run("-vv")
-    result.assert_failed(code=1)
+    result.assert_failed(code=2)
 
 
 def test_uv_venv_skip_missing_interpreters_pass(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
In uv 0.8.0 the exit code for `uv venv` command changed from 1 to 2 in case the python interpreter is not found. This change handles both codes.