### PR TITLE
feat: Support custom package root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 /build
 dist
 src/tox_uv/version.py
+
+uv.lock

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ overwritten by the VIRTUALENV_SYSTEM_SITE_PACKAGES environment variable. This fl
 We use `uv pip` to install packages into the virtual environment. The behavior of this can be configured via the
 following options:
 
+tox-uv resolves your project location based on the `package_root` setting. If that option is not defined, it will
+fall back to the `setupdir` value from `tox.ini`, matching how tox itself locates project files.
+
 ### `uv_resolution`
 
 This flag, set on a tox environment level, informs `uv` of the desired [resolution strategy]:

--- a/src/tox_uv/_package.py
+++ b/src/tox_uv/_package.py
@@ -21,9 +21,9 @@ class UvVenvPep517Packager(Pep517VenvPackager, UvVenv):
     def perform_packaging(self, for_env: EnvConfigSet) -> list[Package]:
         of_type: str = for_env["package"]
         if of_type == UvPackage.KEY:
-            return [UvPackage(self.core["tox_root"], for_env["extras"])]
+            return [UvPackage(self.package_root(), for_env["extras"])]
         if of_type == UvEditablePackage.KEY:
-            return [UvEditablePackage(self.core["tox_root"], for_env["extras"])]
+            return [UvEditablePackage(self.package_root(), for_env["extras"])]
         return super().perform_packaging(for_env)
 
 

--- a/src/tox_uv/_run.py
+++ b/src/tox_uv/_run.py
@@ -28,8 +28,8 @@ class UvVenvRunner(UvVenv, PythonRun):
 
     @property
     def default_pkg_type(self) -> str:
-        tox_root: Path = self.core["tox_root"]
-        if not (any((tox_root / i).exists() for i in ("pyproject.toml", "setup.py", "setup.cfg"))):
+        package_root: Path = self.package_root()
+        if not (any((package_root / i).exists() for i in ("pyproject.toml", "setup.py", "setup.cfg"))):
             return "skip"
         return super().default_pkg_type
 

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -96,7 +96,8 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
                 cmd.append("-v")
             if package == "wheel":
                 # need the package name here but we don't have the packaging infrastructure -> read from pyproject.toml
-                project_file = self.core["tox_root"] / "pyproject.toml"
+                root = self.package_root()
+                project_file = root / "pyproject.toml"
                 name = None
                 if project_file.exists():
                     with project_file.open("rb") as file_handler:
@@ -112,7 +113,14 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             cmd.extend(("-p", self.env_version_spec()))
 
             show = self.options.verbosity > 2  # noqa: PLR2004
-            outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=show)
+            cwd = self.package_root()
+            outcome = self.execute(
+                cmd,
+                stdin=StdinSource.OFF,
+                run_id="uv-sync",
+                show=show,
+                cwd=cwd,
+            )
             outcome.assert_success()
         if install_pkg is not None:
             path = Path(install_pkg)

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -8,6 +8,7 @@ import os
 import sys
 import sysconfig
 from abc import ABC
+from configparser import ConfigParser
 from functools import cached_property
 from importlib.resources import as_file, files
 from pathlib import Path
@@ -309,6 +310,18 @@ class UvVenv(Python, ABC):
             platform=sys.platform,
             extra={},
         )
+
+    def package_root(self) -> Path:
+        try:
+            return self.core["package_root"]
+        except KeyError:
+            config = self.core["tox_root"] / "tox.ini"
+            if config.is_file():
+                parser = ConfigParser()
+                parser.read(config)
+                if parser.has_section("tox") and parser.has_option("tox", "setupdir"):
+                    return self.core["tox_root"] / parser.get("tox", "setupdir")
+            return self.core["tox_root"]
 
 
 __all__ = [

--- a/tests/test_setupdir.py
+++ b/tests/test_setupdir.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def test_setupdir_respected(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+[tox]
+skipsdist = true
+setupdir = src
+env_list = py
+[testenv]
+runner = uv-venv-runner
+commands = python -c 'print("hello")'
+""",
+        "src": {
+            "pyproject.toml": """
+[project]
+name = 'demo'
+version = '0'
+""",
+        },
+    })
+    result = project.run("-e", "py")
+    result.assert_success()
+
+
+def test_setupdir_with_package_root(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+[tox]
+skipsdist = true
+setupdir = src
+env_list = py
+[testenv]
+runner = uv-venv-runner
+package_root = src
+commands = python -c 'print("hello")'
+""",
+        "pyproject.toml": "",
+        "src": {
+            "pyproject.toml": """
+[project]
+name = 'demo'
+version = '0'
+""",
+        },
+    })
+    result = project.run("-e", "py")
+    result.assert_success()


### PR DESCRIPTION
Allow tov-uv to recognize properly a custom package root if any, without enforcing to have pyproject.toml in the same directory of tox.ini

Address issue #220