### PR TITLE
Make sure `tox_on_install()` hook is called in `UvVenvLockRunner._setup_env()`

### DIFF
--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -124,7 +124,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         if install_pkg is not None:
             path = Path(install_pkg)
             pkg = (WheelPackage if path.suffix == ".whl" else SdistPackage)(path, deps=[])
-            self.installer.install([pkg], "install-pkg", of_type="external")
+            self._install([pkg], "install-pkg", of_type="external")
 
     @property
     def environment_variables(self) -> dict[str, str]:


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox-uv/issues/187.
Fixes https://github.com/tox-dev/tox-gh/issues/175.