### PR TITLE
fix: no-managed-python collision with python-preference (#253)

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -72,13 +72,20 @@ class UvVenv(Python, ABC):
             desc="create virtual environments that also have access to globally installed packages.",
         )
 
+        def uv_python_preference_default(conf: object, name: object) -> str:  # noqa: ARG001
+            return (
+                "none"
+                if {"UV_NO_MANAGED_PYTHON", "UV_MANAGED_PYTHON"} & set(os.environ)
+                else os.environ.get("UV_PYTHON_PREFERENCE", "system")
+            )
+
         # The cast(...) might seems superfluous but removing it makes mypy crash. The problem isy on tox typing side.
         self.conf.add_config(
             keys=["uv_python_preference"],
             of_type=cast("Type[Optional[PythonPreference]]", Optional[PythonPreference]),  # type: ignore[valid-type] # noqa: UP006
             # use os.environ here instead of self.environment_variables as this value is needed to create the virtual
             # environment, if environment variables use env_site_packages_dir we would run into a chicken-egg problem.
-            default=lambda conf, name: os.environ.get("UV_PYTHON_PREFERENCE", "system"),  # noqa: ARG005
+            default=uv_python_preference_default,
             desc=(
                 "Whether to prefer using Python installations that are already"
                 " present on the system, or those that are downloaded and"

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -57,6 +57,25 @@ def test_uv_venv_preference_system_by_default(tox_project: ToxProjectCreator) ->
     assert got == "system"
 
 
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+@pytest.mark.parametrize("env_var", ["UV_NO_MANAGED_PYTHON", "UV_MANAGED_PYTHON"])
+def test_uv_venv_preference_not_set_if_uv_no_managed_python(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch, env_var: str
+) -> None:
+    # --(no-)managed-python cannot be used together with --python-preference
+    project = tox_project({"tox.ini": "[testenv]"})
+    monkeypatch.setenv(env_var, "True")
+
+    result = project.run("c", "-k", "uv_python_preference")
+    result.assert_success()
+
+    parser = ConfigParser()
+    parser.read_string(result.out)
+    got = parser["testenv:py"]
+
+    assert got.get("uv_python_preference") == "none"
+
+
 def test_uv_venv_preference_override_via_env_var(
     tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Only handles the environment var case.

To completely handle the problem, we would need to parse and merge all these toml files, for the XDG and Windows cases:
uv.toml/pyproject.toml (project > user > system)

I'd wait with handling the general case, because someone will "reimplement it in Rust"™ https://github.com/astral-sh/uv/issues/6042