### PR TITLE
feat: improve handling of uv_python_preference

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -73,6 +73,11 @@ class UvVenv(Python, ABC):
                 else os.environ.get("UV_PYTHON_PREFERENCE", "system")
             )
 
+        def uv_python_preference_post_process(value: str | None) -> str:
+            if value is not None:
+                return value.lower()
+            return "system"
+
         # The cast(...) might seems superfluous but removing it makes mypy crash. The problem isy on tox typing side.
         self.conf.add_config(
             keys=["uv_python_preference"],
@@ -90,6 +95,7 @@ class UvVenv(Python, ABC):
                 " interpreters with all tox environments and avoid accidental"
                 " downloading of other interpreters."
             ),
+            post_process=uv_python_preference_post_process,
         )
 
     def python_cache(self) -> dict[str, Any]:

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -369,6 +369,35 @@ def test_uv_env_python_preference(
     assert env_bin_dir in result.out
 
 
+@pytest.mark.parametrize(
+    "env",
+    ["3.10", "3.10-onlymanaged"],
+)
+def test_uv_env_python_preference_complex(
+    tox_project: ToxProjectCreator,
+    *,
+    env: str,
+) -> None:
+    project = tox_project({
+        "tox.ini": (
+            "[tox]\n"
+            "env_list =\n"
+            "    3.10\n"
+            "[testenv]\n"
+            "package=skip\n"
+            "uv_python_preference=\n"
+            "    onlymanaged: only-managed\n"
+            "commands=python -c 'print(\"{env_python}\")'"
+        )
+    })
+    result = project.run("-vv", "-e", env)
+    result.assert_success()
+
+    exe = "python.exe" if sys.platform == "win32" else "python"
+    env_bin_dir = str(project.path / ".tox" / env / ("Scripts" if sys.platform == "win32" else "bin") / exe)
+    assert env_bin_dir in result.out
+
+
 def test_uv_env_site_package_dir_run(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[testenv]\npackage=skip\ncommands=python -c 'print(\"{envsitepackagesdir}\")'"})
     result = project.run("-vv")


### PR DESCRIPTION
## Describe your changes

When uv_python_reference is used as variable with values for test environment variants, if the variant does not include it "None" is passed but is not an officially supported value.

"none" being a valid value, simply return the lowered version of what has been passed.

## Issue ticket number and link

Fixes #260 