### PR TITLE
🐛 fix(lock-runner): accept uv/uv-editable package types

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,16 @@ Therefore, options like `deps` are ignored (and all others
 
 How to install the source tree package, must be one of:
 
-- `skip`,
-- `wheel`,
-- `editable` (default),
-- `uv` (use uv to install the project, rather than build wheel via `tox`),
-- `uv-editable` (use uv to install the project in editable mode, rather than build wheel via `tox`).
+- `skip` - do not install the project,
+- `wheel` - install the project as a non-editable wheel,
+- `editable` (default) - install the project in editable mode,
+- `uv` - with `uv-venv-runner` uses uv directly to install the project (bypassing tox's PEP-517 packaging), with
+  `uv-venv-lock-runner` behaves like `wheel`,
+- `uv-editable` - with `uv-venv-runner` uses uv directly to install in editable mode (bypassing tox's PEP-517
+  packaging), with `uv-venv-lock-runner` behaves like `editable`.
 
-You should use the latter two in case you need to use any non-standard features of `uv`, such as `tool.uv.sources`.
+With `uv-venv-runner`, prefer `uv`/`uv-editable` when you need non-standard features of `uv`, such as `tool.uv.sources`.
+With `uv-venv-lock-runner`, `uv sync` already handles installation natively so all modes work through it.
 
 ### `extras`
 

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -71,7 +71,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         )
         self.conf.add_config(  # type: ignore[call-overload]
             keys=["package"],
-            of_type=Literal["editable", "wheel", "skip"],
+            of_type=Literal["editable", "wheel", "skip", "uv", "uv-editable"],
             default="editable",
             desc="How should the package be installed",
         )
@@ -101,7 +101,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
                 cmd.append("--no-install-project")
             if self.options.verbosity > 3:  # noqa: PLR2004
                 cmd.append("-v")
-            if package == "wheel":
+            if package in {"wheel", "uv"}:
                 # need the package name here but we don't have the packaging infrastructure -> read from pyproject.toml
                 project_file = self.core["tox_root"] / "pyproject.toml"
                 name = None

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -494,13 +494,14 @@ def test_skip_uv_sync(tox_project: ToxProjectCreator, monkeypatch: pytest.Monkey
     assert calls == expected
 
 
-def test_uv_package_wheel(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("package", ["wheel", "uv"])
+def test_uv_package_non_editable(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch, package: str) -> None:
     monkeypatch.delenv("UV_PYTHON_PREFERENCE", raising=False)
     project = tox_project({
-        "tox.toml": """
+        "tox.toml": f"""
             [env_run_base]
             runner = "uv-venv-lock-runner"
-            package = "wheel"
+            package = "{package}"
             """,
         "pyproject.toml": """
             [project]
@@ -549,13 +550,16 @@ def test_uv_package_wheel(tox_project: ToxProjectCreator, monkeypatch: pytest.Mo
     assert calls == expected
 
 
-def test_uv_package_wheel_no_pyproject(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("package", ["wheel", "uv"])
+def test_uv_package_non_editable_no_pyproject(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch, package: str
+) -> None:
     monkeypatch.delenv("UV_PYTHON_PREFERENCE", raising=False)
     project = tox_project({
-        "tox.toml": """
+        "tox.toml": f"""
             [env_run_base]
             runner = "uv-venv-lock-runner"
-            package = "wheel"
+            package = "{package}"
             """,
     })
     project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
@@ -563,6 +567,54 @@ def test_uv_package_wheel_no_pyproject(tox_project: ToxProjectCreator, monkeypat
     result = project.run("run", "--notest")
 
     result.assert_failed()
+
+
+def test_uv_package_uv_editable(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UV_PYTHON_PREFERENCE", raising=False)
+    project = tox_project({
+        "tox.toml": """
+            [env_run_base]
+            runner = "uv-venv-lock-runner"
+            package = "uv-editable"
+            """,
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
+    result = project.run("run", "--notest")
+    result.assert_success()
+
+    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    uv = find_uv_bin()
+
+    expected = [
+        (
+            "py",
+            "venv",
+            [
+                uv,
+                "venv",
+                "-p",
+                sys.executable,
+                "--allow-existing",
+                "--python-preference",
+                "system",
+                str(project.path / ".tox" / "py"),
+            ],
+        ),
+        (
+            "py",
+            "uv-sync",
+            [
+                "uv",
+                "sync",
+                "--locked",
+                "--python-preference",
+                "system",
+                "-p",
+                sys.executable,
+            ],
+        ),
+    ]
+    assert calls == expected
 
 
 def test_skip_uv_package_skip(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Users switching from `uv-venv-runner` to `uv-venv-lock-runner` hit a `ValueError` when using `package = "uv"` because the lock runner only accepted `editable`, `wheel`, and `skip`. This was confusing since both runners advertise the same `package` config key but silently disagreed on valid values. 🐛

Since the lock runner uses `uv sync` natively, `package = "uv"` is functionally equivalent to `"wheel"` (non-editable install) and `package = "uv-editable"` is equivalent to `"editable"`. Rather than rejecting these values, the lock runner now accepts them and maps to the corresponding behavior. This lets users share the same tox config across both runners without surprises.

📝 The `package` documentation has been rewritten to describe per-runner behavior for all five values, making the relationship between runners clearer.

Fixes #183