### PR TITLE
🐛 fix(installer): handle list-type uv sources

### DIFF
--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -116,7 +116,7 @@ class UvInstaller(Pip):
             pyproject = tomllib.load(file_handler)
 
         sources = pyproject.get("tool", {}).get("uv", {}).get("sources", {})
-        return {key for key, val in sources.items() if val.get("workspace", False)}
+        return {key for key, val in sources.items() if isinstance(val, dict) and val.get("workspace", False)}
 
     def _install_list_of_deps(  # noqa: C901, PLR0912
         self,

--- a/tests/test_tox_uv_package.py
+++ b/tests/test_tox_uv_package.py
@@ -54,6 +54,26 @@ def test_uv_package_requirements(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
 
+def test_uv_package_list_sources(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
+    ini = """
+    [testenv]
+    """
+    project = tox_project({"tox.ini": ini}, base=demo_pkg_inline)
+    pyproject = project.path / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text()
+        + """\
+[tool.uv.sources]
+some-dep = [
+  {index = "foo", marker = "sys_platform == 'linux'"},
+  {index = "bar", marker = "sys_platform == 'darwin'"},
+]
+"""
+    )
+    result = project.run()
+    result.assert_success()
+
+
 def test_uv_package_workspace(tox_project: ToxProjectCreator, demo_pkg_workspace: Path) -> None:
     """Tests ability to install uv workspace projects."""
     ini = """


### PR DESCRIPTION
Projects using forked dependencies like multi-backend PyTorch define `tool.uv.sources` entries as lists of dicts with platform markers, rather than a single dict. 🔥 This caused `_sourced_pkg_names` to crash with `AttributeError: 'list' object has no attribute 'get'`, making tox-uv completely unusable for these projects.

The fix adds a type check before accessing `.get("workspace")` on source values, skipping list entries since workspace sources are always single dicts. This is the minimal change needed to restore compatibility without altering workspace detection behavior.

Fixes #243