### PR TITLE
🐛 fix(venv): resolve relative workdir with changedir

### DIFF
--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -102,7 +102,10 @@ class UvVenv(Python, ABC):
         result["seed"] = self.conf["uv_seed"]
         if self.conf["uv_python_preference"] != "none":
             result["python_preference"] = self.conf["uv_python_preference"]
-        result["venv"] = str(self.venv_dir.relative_to(self.env_dir))
+        env_dir = cast("Path", self.conf["env_dir"])
+        if not env_dir.is_absolute():
+            env_dir = cast("Path", self.core["tox_root"]) / env_dir
+        result["venv"] = str(self.venv_dir.relative_to(env_dir))
         return result
 
     @property
@@ -187,7 +190,10 @@ class UvVenv(Python, ABC):
 
     @property
     def venv_dir(self) -> Path:
-        return cast("Path", self.conf["env_dir"])
+        result = cast("Path", self.conf["env_dir"])
+        if not result.is_absolute():
+            result = cast("Path", self.core["tox_root"]) / result
+        return result
 
     @property
     def environment_variables(self) -> dict[str, str]:

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -623,3 +623,21 @@ def test_env_version_spec_free_threaded() -> None:
     uv_venv.set_base_python(python_info)
     with mock.patch("sys.version_info", (0, 0, 0)):  # prevent picking sys.executable
         assert uv_venv.env_version_spec() == "cpython3.13+freethreaded"
+
+
+def test_relative_workdir_with_changedir(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """\
+[tox]
+toxworkdir=.tox
+
+[testenv:demo]
+changedir={toxinidir}/sub
+package = skip
+commands = python -c "print('ok')"
+allowlist_externals = python
+""",
+    })
+    (project.path / "sub").mkdir()
+    result = project.run("-e", "demo")
+    result.assert_success()


### PR DESCRIPTION
When `toxworkdir` is set to a relative path (e.g. `toxworkdir=.tox`) and a test environment uses `changedir` to move into a subdirectory, tox-uv fails because the relative `env_dir` path cannot be resolved from the new working directory. 🐛 Vanilla tox handles this correctly since it resolves paths early, but tox-uv's `venv_dir` property was passing through the relative path unchanged.

The fix resolves relative `env_dir` paths against `tox_root` in the `venv_dir` property, ensuring venv operations always work with absolute paths regardless of `changedir`. The same resolution is applied in `python_cache` to keep the cache key computation consistent.

This is a non-breaking change — absolute `env_dir` paths (the common case when `toxworkdir` is not explicitly set) pass through unchanged.

Fixes #268