### PR TITLE
🐛 fix(lock): use bundled uv binary for uv sync

### DIFF
--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -91,7 +91,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             if not package_root.is_absolute():
                 package_root = self.core["tox_root"] / package_root
             cmd = [
-                "uv",
+                self.uv,
                 "sync",
             ]
             if package_root != self.core["tox_root"]:

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -46,7 +46,7 @@ package_root = src
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--directory",
                 str(project.path / "src"),
@@ -100,7 +100,7 @@ def test_uv_lock_list_dependencies_command(tox_project: ToxProjectCreator) -> No
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -162,7 +162,7 @@ def test_uv_lock_command(tox_project: ToxProjectCreator, verbose: str) -> None:
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -214,7 +214,7 @@ def test_uv_lock_with_default_groups(tox_project: ToxProjectCreator) -> None:
                 str(project.path / ".tox" / "py"),
             ],
         ),
-        ("py", "uv-sync", ["uv", "sync", "--locked", "--python-preference", "system", "-v", "-p", sys.executable]),
+        ("py", "uv-sync", [uv, "sync", "--locked", "--python-preference", "system", "-v", "-p", sys.executable]),
     ]
     assert calls == expected
 
@@ -262,7 +262,7 @@ def test_uv_lock_with_install_pkg(tox_project: ToxProjectCreator, name: str) -> 
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -322,7 +322,7 @@ def test_uv_sync_extra_flags(tox_project: ToxProjectCreator, uv_sync_locked: boo
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 *(["--locked"] if uv_sync_locked else []),
                 "--python-preference",
@@ -375,7 +375,7 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -428,7 +428,7 @@ def test_uv_sync_dependency_groups(tox_project: ToxProjectCreator) -> None:
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -492,7 +492,7 @@ def test_uv_sync_uv_python_preference(
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 *injected,
@@ -586,7 +586,7 @@ def test_uv_package_non_editable(tox_project: ToxProjectCreator, monkeypatch: py
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -656,7 +656,7 @@ def test_uv_package_uv_editable(tox_project: ToxProjectCreator, monkeypatch: pyt
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -704,7 +704,7 @@ def test_skip_uv_package_skip(tox_project: ToxProjectCreator, monkeypatch: pytes
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",
@@ -752,7 +752,7 @@ def test_uv_lock_ith_resolution(tox_project: ToxProjectCreator) -> None:
             "py",
             "uv-sync",
             [
-                "uv",
+                uv,
                 "sync",
                 "--locked",
                 "--python-preference",


### PR DESCRIPTION
When a project sets `tool.uv.required-version` in `pyproject.toml` and the system-installed uv is older than that constraint, `uv sync` in the lock runner fails with `Required uv version does not match the running version`. 🐛 This happens because the lock runner invokes a bare `"uv"` string that gets resolved via PATH to the system binary, while all other commands (`uv venv`, `uv pip install`, `uv pip freeze`) already use `self.uv` which resolves to the bundled binary from `find_uv_bin()`.

The fix aligns `uv sync` with every other uv invocation by using `self.uv` instead of a hardcoded string. This ensures the bundled uv version (which tox-uv pins as a dependency) is always used, avoiding version mismatches with `required-version` constraints.

No behavioral change for users whose system uv matches or exceeds the bundled version. Users who previously hit this error no longer need to manually update their system uv.

Fixes #239