### PR TITLE
✨ feat(lock): add only_groups config for uv sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ will get both the benefits (performance) or downsides (bugs) of `uv`.
   - [extras](#extras)
   - [no_default_groups](#no_default_groups)
   - [dependency_groups](#dependency_groups)
+  - [only_groups](#only_groups)
   - [uv_sync_flags](#uv_sync_flags)
   - [uv_sync_locked](#uv_sync_locked)
   - [External package support](#external-package-support)
@@ -124,7 +125,19 @@ will be `true` if the `dependency_groups` is not empty and `false` otherwise.
 
 ### `dependency_groups`
 
-Specify [PEP 735 – Dependency Groups](https://peps.python.org/pep-0735/) to install.
+Specify [PEP 735 – Dependency Groups](https://peps.python.org/pep-0735/) to install **in addition to** the project and
+its dependencies (maps to `uv sync --group`). For example, `dependency_groups = ["test", "docs"]` installs the project,
+its default dependencies, and the `test` and `docs` groups.
+
+### `only_groups`
+
+Install **only** these [PEP 735 – Dependency Groups](https://peps.python.org/pep-0735/), excluding the project and all
+other dependencies (maps to `uv sync --only-group`). Use this when you need a dependency group in complete isolation,
+such as CI tooling from a private index. For example, `only_groups = ["ci"]` installs only the `ci` group without the
+project or any of its dependencies.
+
+**Key difference**: `dependency_groups` adds groups to the standard install, while `only_groups` replaces the entire
+install with just those groups.
 
 ### `uv_sync_flags`
 

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -52,6 +52,12 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             desc="dependency groups to install of the target package",
         )
         self.conf.add_config(
+            keys=["only_groups"],
+            of_type=set[str],
+            default=set(),
+            desc="install only these dependency groups (maps to uv sync --only-group)",
+        )
+        self.conf.add_config(
             keys=["no_default_groups"],
             of_type=bool,
             default=lambda _, __: bool(self.conf["dependency_groups"]),
@@ -125,6 +131,8 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
                 cmd.extend(("--no-editable", "--reinstall-package", name))
             for group in groups:
                 cmd.extend(("--group", group))
+            for group in sorted(self.conf["only_groups"]):
+                cmd.extend(("--only-group", group))
             cmd.extend(self.conf["uv_sync_flags"])
             cmd.extend(("-p", self.env_version_spec()))
 


### PR DESCRIPTION
Users who need to install a single dependency group in isolation -- for example, CI tooling from a private index without pulling in the project or its other dependencies -- had to resort to `uv_sync_flags = --only-group,my-group` as a workaround. This works but is non-obvious and mixes flag-level details into the tox config.

This adds a first-class `only_groups` config for the lock runner that maps directly to `uv sync --only-group`. It follows the same pattern as the existing `dependency_groups` config: accepts a set of group names and emits `--only-group <name>` flags for each.

```toml
[testenv:ci]
runner = uv-venv-lock-runner
only_groups = ["ci"]
```

Closes #267