### PR TITLE
🐛 fix(runner): combine deps and dependency groups for uv_resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,4 +203,9 @@ This flag, set on a tox environment level, informs `uv` of the desired [resoluti
 This is an `uv` specific feature that may be used as an alternative to frozen constraints for test environments if the
 intention is to validate the lower bounds of your dependencies during test executions.
 
+**Note**: When using `uv_resolution` with `dependency_groups`, all dependencies from both `deps` and `dependency_groups`
+are combined into a single install operation. This ensures the resolution strategy applies correctly across all
+requirements, preventing sequential installations from resolving transitive dependencies before the strategy can apply
+to overlapping direct dependencies.
+
 [resolution strategy]: https://github.com/astral-sh/uv/blob/0.1.20/README.md#resolution-strategy


### PR DESCRIPTION
When using uv_resolution strategies like lowest-direct with PEP 735 dependency groups, tox core installs dependencies sequentially: first deps, then dependency_groups. This causes uv to resolve transitive dependencies from dependency_groups at their latest versions before the resolution strategy can apply to direct dependencies from deps, defeating the purpose of lowest-direct.

The fix overrides _setup_env() in UvVenvRunner to detect when both uv_resolution and dependency_groups are configured, then combines all requirements into a single install operation. This ensures the resolution strategy applies consistently across all dependencies, both direct and transitive.

Fixes #244