### PR TITLE
♻️ refactor(runner): delegate setup orchestration to parent class

### DIFF
--- a/src/tox_uv/_run.py
+++ b/src/tox_uv/_run.py
@@ -42,12 +42,7 @@ class UvVenvRunner(UvVenv, PythonRun):
     def _package_types(self) -> tuple[str, ...]:
         return *super()._package_types, UvPackage.KEY, UvEditablePackage.KEY
 
-    def _setup_env(self) -> None:
-        super(PythonRun, self)._setup_env()
-        if getattr(self.options, "skip_env_install", False):
-            _LOGGER.warning("skip installing dependencies and package")
-            return
-
+    def _install_deps(self) -> None:
         groups: set[str] = self.conf["dependency_groups"]
         uv_resolution: str = self.conf["uv_resolution"]
 
@@ -66,11 +61,16 @@ class UvVenvRunner(UvVenv, PythonRun):
                 uv_resolution,
             )
             self._install(combined_reqs, PythonRun.__name__, "deps")
-        elif self.conf["pylock"]:
-            self._install_pylock()
         else:
-            self._install_deps()
-            self._install_dependency_groups()
+            super()._install_deps()
+
+    def _install_dependency_groups(self) -> None:
+        groups: set[str] = self.conf["dependency_groups"]
+        uv_resolution: str = self.conf["uv_resolution"]
+
+        if uv_resolution and groups:
+            return
+        super()._install_dependency_groups()
 
 
 __all__ = [


### PR DESCRIPTION
PR #294 introduced a fix for combining deps with dependency_groups when using uv_resolution, but it duplicated parent class logic by overriding `_setup_env()` and re-implementing checks for `skip_env_install` and `pylock`. This created maintenance burden and risked divergence if the parent class changed those behaviors. ♻️

The refactored implementation overrides only `_install_deps()` and `_install_dependency_groups()` instead of the entire setup flow. The parent's `_setup_env()` now handles all orchestration (venv creation, skip_env_install, pylock checks) while the child class only customizes the specific behavior of combining requirements when both `uv_resolution` and `dependency_groups` are configured.

This reduces code duplication, makes the intent clearer, and ensures we automatically inherit any future parent class improvements to the setup orchestration logic.