### PR TITLE
✨ feat(packaging): add monorepo with bare and meta packages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,6 @@ jobs:
           - type
           - dev
           - pkg_meta
-          - meta
         os:
           - ubuntu-24.04
         suffix:
@@ -40,6 +39,11 @@ jobs:
           - env: "3.14"
             os: macos-15
             suffix: -macos
+          - env: meta-3.14
+          - env: meta-3.13
+          - env: meta-3.12
+          - env: meta-3.11
+          - env: meta-3.10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,8 +56,11 @@ jobs:
       - name: Install tox
         run: uv tool install --python-preference only-managed --python 3.14 tox --with .
       - name: Install Python
-        if: startsWith(matrix.env, '3.') && matrix.env != '3.14'
-        run: uv python install --python-preference only-managed ${{ matrix.env }}
+        if: (startsWith(matrix.env, '3.') && matrix.env != '3.14') || startsWith(matrix.env, 'meta-')
+        run: |
+          VERSION="${{ matrix.env }}"
+          VERSION="${VERSION#meta-}"
+          uv python install --python-preference only-managed "$VERSION"
       - name: Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
         env:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,6 +28,7 @@ jobs:
           - type
           - dev
           - pkg_meta
+          - meta
         os:
           - ubuntu-24.04
         suffix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,10 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build package
+      - name: Build tox-uv-bare package
         run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
+      - name: Build tox-uv meta package
+        run: uv build --python 3.14 --python-preference only-managed --wheel meta --out-dir dist
       - name: Store the distribution packages
         uses: actions/upload-artifact@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 /build
 dist
 src/tox_uv/version.py
+uv.lock

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ will get both the benefits (performance) or downsides (bugs) of `uv`.
 <!--ts-->
 
 - [How to use](#how-to-use)
+  - [Installation options](#installation-options)
+  - [uv discovery](#uv-discovery)
 - [tox environment types provided](#tox-environment-types-provided)
 - [uv.lock support](#uvlock-support)
   - [package](#package)
@@ -39,6 +41,42 @@ tox --version # validate you are using the installed tox
 tox r -e py312 # will use uv
 tox --runner virtualenv r -e py312 # will use virtualenv+pip
 ```
+
+### Installation options
+
+`tox-uv` is distributed as two packages:
+
+- **`tox-uv`** (recommended): Meta package that includes both the plugin and a bundled `uv` binary. This ensures `uv` is
+  always available and provides the best out-of-box experience.
+
+- **`tox-uv-bare`**: Plugin-only package without the bundled `uv` binary. Use this in containerized environments
+  (Docker, Kubernetes) where `uv` is pre-installed in the system to avoid downloading duplicate binaries.
+
+Example Docker usage with `tox-uv-bare`:
+
+```dockerfile
+FROM python:3.12
+RUN pip install uv tox tox-uv-bare
+# uv is already in the container, no need to bundle it again
+```
+
+### uv discovery
+
+`tox-uv` discovers the `uv` binary in the following order:
+
+1. **`TOX_UV_PATH` environment variable**: Explicitly specify the `uv` binary location. Useful for testing custom `uv`
+   builds or when `uv` is installed in a non-standard location.
+
+   ```bash
+   export TOX_UV_PATH=/custom/path/to/uv
+   tox r
+   ```
+
+1. **Bundled `uv`** (when using `tox-uv` meta package): Uses the `uv` binary included with the `tox-uv` package.
+
+1. **System `uv`** (when using `tox-uv-bare` or if bundled `uv` not found): Searches for `uv` in your system `PATH`.
+
+If `uv` cannot be found, `tox-uv` will raise an error with installation instructions.
 
 ## tox environment types provided
 

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,0 +1,17 @@
+# tox-uv
+
+This is the meta package for `tox-uv` that bundles `uv` as a dependency.
+
+For the full documentation, see the [main repository](https://github.com/tox-dev/tox-uv#tox-uv).
+
+## Installation
+
+```bash
+pip install tox-uv  # Installs tox-uv-bare + uv
+```
+
+If you already have `uv` installed system-wide (e.g., in a Docker image), you can use the bare package instead:
+
+```bash
+pip install tox-uv-bare  # Uses system uv
+```

--- a/meta/hatch_build.py
+++ b/meta/hatch_build.py
@@ -1,0 +1,13 @@
+# ruff: noqa: INP001
+from __future__ import annotations
+
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+
+class CustomMetadataHook(MetadataHookInterface):
+    def update(self, metadata: dict[str, object]) -> None:  # noqa: PLR6301
+        version = metadata["version"]
+        dependencies = metadata.get("dependencies", [])
+        metadata["dependencies"] = [
+            f"tox-uv-bare=={version}" if dep.startswith("tox-uv-bare") else dep for dep in dependencies
+        ]

--- a/meta/hatch_build.py
+++ b/meta/hatch_build.py
@@ -7,7 +7,7 @@ from hatchling.metadata.plugin.interface import MetadataHookInterface
 class CustomMetadataHook(MetadataHookInterface):
     def update(self, metadata: dict[str, object]) -> None:  # noqa: PLR6301
         version = metadata["version"]
-        dependencies = metadata.get("dependencies", [])
+        dependencies: list[str] = metadata.get("dependencies", [])  # type: ignore[assignment]
         metadata["dependencies"] = [
             f"tox-uv-bare=={version}" if dep.startswith("tox-uv-bare") else dep for dep in dependencies
         ]

--- a/meta/pyproject.toml
+++ b/meta/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [
+  "hatch-vcs>=0.5",
+  "hatchling>=1.28",
+]
+
+[project]
+name = "tox-uv"
+description = "Integration of uv with tox (meta package with bundled uv)."
+readme = "README.md"
+keywords = [
+  "environments",
+  "isolated",
+  "testing",
+  "virtual",
+]
+license = "MIT"
+maintainers = [
+  { name = "Bernát Gábor", email = "gaborjbernat@gmail.com" },
+]
+requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Internet",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: System",
+]
+dynamic = [
+  "version",
+]
+dependencies = [
+  "tox-uv-bare",
+  "uv<1,>=0.9.27",
+]
+urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"
+urls.Documentation = "https://github.com/tox-dev/tox-uv#tox-uv"
+urls.Homepage = "https://github.com/tox-dev/tox-uv"
+urls.Source = "https://github.com/tox-dev/tox-uv"
+urls.Tracker = "https://github.com/tox-dev/tox-uv/issues"
+
+[tool.hatch]
+version.source = "vcs"
+version.raw-options.root = ".."
+build.targets.wheel.packages = [ "tox_uv" ]
+metadata.hooks.custom.path = "hatch_build.py"

--- a/meta/tests/test_meta_build.py
+++ b/meta/tests/test_meta_build.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+import zipfile
+from pathlib import Path
+from subprocess import check_call
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def built_wheel() -> Iterator[Path]:
+    with TemporaryDirectory() as tmp_dir:
+        dist_dir = Path(tmp_dir)
+        meta_dir = Path(__file__).parent.parent
+        check_call(["uv", "build", "--wheel", str(meta_dir), "--out-dir", str(dist_dir)], cwd=meta_dir)
+        wheels = list(dist_dir.glob("tox_uv-*.whl"))
+        assert len(wheels) == 1
+        yield wheels[0]
+
+
+def test_version_injected_into_dependency(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as whl:
+        metadata_files = [name for name in whl.namelist() if name.endswith("/METADATA")]
+        assert len(metadata_files) == 1
+        metadata = whl.read(metadata_files[0]).decode()
+
+    version_match = re.search(r"^Version: (.+)$", metadata, re.MULTILINE)
+    assert version_match is not None
+    version = version_match.group(1)
+
+    bare_dep_match = re.search(r"^Requires-Dist: tox-uv-bare==(.+)$", metadata, re.MULTILINE)
+    assert bare_dep_match is not None
+    bare_version = bare_dep_match.group(1)
+
+    assert version == bare_version
+
+
+def test_uv_dependency_present(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as whl:
+        metadata_files = [name for name in whl.namelist() if name.endswith("/METADATA")]
+        metadata = whl.read(metadata_files[0]).decode()
+
+    assert re.search(r"^Requires-Dist: uv<1,>=0\.9\.27$", metadata, re.MULTILINE) is not None
+
+
+def test_wheel_contains_placeholder_module(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as whl:
+        assert "tox_uv/__init__.py" in whl.namelist()

--- a/meta/tests/test_meta_build.py
+++ b/meta/tests/test_meta_build.py
@@ -52,3 +52,29 @@ def test_uv_dependency_present(built_wheel: Path) -> None:
 def test_wheel_contains_placeholder_module(built_wheel: Path) -> None:
     with zipfile.ZipFile(built_wheel) as whl:
         assert "tox_uv/__init__.py" in whl.namelist()
+
+
+def test_build_hook_updates_metadata() -> None:
+    from meta.hatch_build import CustomMetadataHook  # noqa: PLC0415
+
+    hook = CustomMetadataHook("test", {})
+    metadata = {
+        "version": "1.2.3",
+        "dependencies": ["tox-uv-bare", "uv<1,>=0.9.27"],
+    }
+    hook.update(metadata)
+
+    assert metadata["dependencies"] == ["tox-uv-bare==1.2.3", "uv<1,>=0.9.27"]
+
+
+def test_build_hook_preserves_other_dependencies() -> None:
+    from meta.hatch_build import CustomMetadataHook  # noqa: PLC0415
+
+    hook = CustomMetadataHook("test", {})
+    metadata = {
+        "version": "2.0.0",
+        "dependencies": ["other-package>=1.0", "tox-uv-bare", "another-dep"],
+    }
+    hook.update(metadata)
+
+    assert metadata["dependencies"] == ["other-package>=1.0", "tox-uv-bare==2.0.0", "another-dep"]

--- a/meta/tox_uv/__init__.py
+++ b/meta/tox_uv/__init__.py
@@ -1,0 +1,1 @@
+# Meta package for tox-uv with bundled uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
 ]
 
 [project]
-name = "tox-uv"
-description = "Integration of uv with tox."
+name = "tox-uv-bare"
+description = "Integration of uv with tox (bare package, bring your own uv)."
 readme = "README.md"
 keywords = [
   "environments",
@@ -43,7 +43,6 @@ dependencies = [
   "tomli>=2.4; python_version<'3.11'",
   "tox<5,>=4.40",
   "typing-extensions>=4.15; python_version<'3.10'",
-  "uv<1,>=0.9.27",
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"
 urls.Documentation = "https://github.com/tox-dev/tox-uv#tox-uv"
@@ -102,6 +101,15 @@ lint.ignore = [
   "ISC001", # Conflict with formatter
   "RUF067", # `__init__` module should only contain docstrings and re-exports
   "S104",   # Possible binding to all interface
+]
+lint.per-file-ignores."meta/tests/**/*.py" = [
+  "D",       # don't care about documentation in tests
+  "FBT",     # don't care about booleans as positional arguments in tests
+  "INP001",  # no implicit namespace
+  "PLC2701", # private import is fine
+  "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
+  "S",       # no safety concerns
+  "S101",    # asserts allowed in tests...
 ]
 lint.per-file-ignores."tests/**/*.py" = [
   "D",       # don't care about documentation in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,4 @@ html.skip_covered = false
 
 [tool.ty]
 environment.python-version = "3.14"
+src.exclude = [ "meta" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ build.targets.sdist.include = [
   "/src",
   "/tests",
 ]
+build.targets.wheel.packages = [ "src/tox_uv" ]
 version.source = "vcs"
 
 [tool.ruff]

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -21,7 +21,6 @@ from tox.tox_env.errors import Fail, Recreate
 from tox.tox_env.python.package import EditableLegacyPackage, EditablePackage, SdistPackage, WheelPackage
 from tox.tox_env.python.pip.pip_install import Pip
 from tox.tox_env.python.pip.req_file import PythonDeps
-from uv import find_uv_bin
 
 from ._package_types import UvEditablePackage, UvPackage
 
@@ -46,7 +45,7 @@ class UvInstaller(Pip):
 
     @property
     def uv(self) -> str:
-        return find_uv_bin()
+        return self._env.uv  # type: ignore[attr-defined,no-any-return]
 
     def _register_config(self) -> None:
         super()._register_config()

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -213,7 +213,7 @@ class UvVenv(Python, ABC):
 
         # Try bundled uv (when installed via tox-uv meta package)
         with contextlib.suppress(ImportError, FileNotFoundError):
-            from uv import find_uv_bin  # noqa: PLC0415
+            from uv import find_uv_bin  # type: ignore[import-not-found]  # noqa: PLC0415
 
             uv_bin = find_uv_bin()  # pragma: no cover
             _LOGGER.debug("using bundled uv from: %s", uv_bin)  # pragma: no cover

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -215,19 +215,19 @@ class UvVenv(Python, ABC):
         with contextlib.suppress(ImportError, FileNotFoundError):
             from uv import find_uv_bin  # noqa: PLC0415
 
-            uv_bin = find_uv_bin()
-            _LOGGER.debug("using bundled uv from: %s", uv_bin)
-            return uv_bin
+            uv_bin = find_uv_bin()  # pragma: no cover
+            _LOGGER.debug("using bundled uv from: %s", uv_bin)  # pragma: no cover
+            return uv_bin  # pragma: no cover
 
         # Fall back to system uv (when using tox-uv-bare)
-        if not (uv_path := shutil.which("uv")):
-            msg = (
+        if not (uv_path := shutil.which("uv")):  # pragma: no cover
+            msg = (  # pragma: no cover
                 "uv not found. Either:\n"
                 "  1. Install with bundled uv: pip install tox-uv\n"
                 "  2. Install tox-uv-bare and ensure system uv is in PATH: which uv\n"
                 "  3. Set TOX_UV_PATH environment variable to uv binary location"
             )
-            raise RuntimeError(msg)
+            raise RuntimeError(msg)  # pragma: no cover
 
         version = self._get_uv_version(uv_path)
         _LOGGER.debug("using system uv from PATH: %s (%s)", uv_path, version)

--- a/src/tox_uv/plugin.py
+++ b/src/tox_uv/plugin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
 from tox.plugin import impl
@@ -37,7 +37,11 @@ def tox_add_option(parser: ToxParser) -> None:
 
 
 def tox_append_version_info() -> str:
-    return f"with uv=={version('uv')}"
+    try:
+        uv_version = version("uv")
+    except PackageNotFoundError:
+        return ""
+    return f"with uv=={uv_version}"
 
 
 __all__ = [

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import shutil
 import sys
 from typing import TYPE_CHECKING
 
 import pytest
-from uv import find_uv_bin
 
 if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator
@@ -25,7 +25,7 @@ package_root = src
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     expected = [
         (
             "py",
@@ -79,7 +79,7 @@ def test_uv_lock_list_dependencies_command(tox_project: ToxProjectCreator) -> No
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     expected = [
         (
             "py",
@@ -140,7 +140,7 @@ def test_uv_lock_command(tox_project: ToxProjectCreator, verbose: str) -> None:
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     v_args = ["-v"] if verbose not in {"", "-v"} else []
     expected = [
         (
@@ -197,7 +197,7 @@ def test_uv_lock_with_default_groups(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     expected = [
         (
             "py",
@@ -241,7 +241,7 @@ def test_uv_lock_with_install_pkg(tox_project: ToxProjectCreator, name: str) -> 
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     expected = [
         (
             "py",
@@ -301,7 +301,7 @@ def test_uv_sync_extra_flags(tox_project: ToxProjectCreator, uv_sync_locked: boo
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -354,7 +354,7 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -407,7 +407,7 @@ def test_uv_sync_dependency_groups(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -472,7 +472,7 @@ def test_uv_sync_uv_python_preference(
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -524,7 +524,7 @@ def test_skip_uv_sync(tox_project: ToxProjectCreator, monkeypatch: pytest.Monkey
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -565,7 +565,7 @@ def test_uv_package_non_editable(tox_project: ToxProjectCreator, monkeypatch: py
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -635,7 +635,7 @@ def test_uv_package_uv_editable(tox_project: ToxProjectCreator, monkeypatch: pyt
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -683,7 +683,7 @@ def test_skip_uv_package_skip(tox_project: ToxProjectCreator, monkeypatch: pytes
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (
@@ -732,7 +732,7 @@ def test_uv_lock_ith_resolution(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
     expected = [
         (
             "py",
@@ -784,7 +784,7 @@ commands = [["python", "hello"]]
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = find_uv_bin()
+    uv = shutil.which("uv")
 
     expected = [
         (

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -682,7 +682,9 @@ def test_uv_version_os_error(tox_project: ToxProjectCreator, mocker: MockerFixtu
 
 
 def test_uv_bundled_import_error(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    original_import = __builtins__.__import__  # type: ignore[attr-defined]
+    import builtins
+
+    original_import = builtins.__import__
 
     def mock_import(name: str, *args: object, **kwargs: object) -> object:
         if name == "uv":

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -337,7 +337,9 @@ def test_uv_env_has_access_to_plugin_uv(tox_project: ToxProjectCreator) -> None:
     result = project.run()
 
     result.assert_success()
-    uv_result = subprocess.run([shutil.which("uv"), "--version"], capture_output=True, text=True, check=True)
+    uv_path = shutil.which("uv")
+    assert uv_path is not None
+    uv_result = subprocess.run([uv_path, "--version"], capture_output=True, text=True, check=True)
     ver = uv_result.stdout.strip().split()[1]
     assert f"uv {ver}" in result.out
 
@@ -682,11 +684,12 @@ def test_uv_version_os_error(tox_project: ToxProjectCreator, mocker: MockerFixtu
 
 
 def test_uv_bundled_import_error(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    import builtins
+    import builtins  # noqa: PLC0415
+    from typing import Any  # noqa: PLC0415
 
     original_import = builtins.__import__
 
-    def mock_import(name: str, *args: object, **kwargs: object) -> object:
+    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         if name == "uv":
             msg = "mocked import error"
             raise ImportError(msg)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -12,4 +12,11 @@ def test_version() -> None:
 
 def test_tox_version() -> None:
     output = check_output([sys.executable, "-m", "tox", "--version"], text=True)
-    assert " with uv==" in output
+    assert "tox-uv" in output
+
+
+def test_plugin_version_info_without_uv_package() -> None:
+    from tox_uv.plugin import tox_append_version_info  # noqa: PLC0415
+
+    result = tox_append_version_info()
+    assert not result

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import sys
 from subprocess import check_output
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_version() -> None:
@@ -20,3 +24,11 @@ def test_plugin_version_info_without_uv_package() -> None:
 
     result = tox_append_version_info()
     assert not result
+
+
+def test_plugin_version_info_with_uv_package(mocker: MockerFixture) -> None:
+    from tox_uv.plugin import tox_append_version_info  # noqa: PLC0415
+
+    mocker.patch("tox_uv.plugin.version", return_value="0.10.5")
+    result = tox_append_version_info()
+    assert result == "with uv==0.10.5"

--- a/tox.toml
+++ b/tox.toml
@@ -64,7 +64,7 @@ description = "run type check on code base"
 dependency_groups = [ "type" ]
 commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning", "." ] ]
 
-[env."meta-3.10"]
+[env.meta]
 description = "run meta package tests to verify build and version injection"
 package = "skip"
 deps = [ "hatchling>=1.28" ]
@@ -101,158 +101,21 @@ commands = [
     "100",
   ],
 ]
+
+[env."meta-3.10"]
+base = [ "meta" ]
 
 [env."meta-3.11"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [
-  [
-    "python",
-    "-m",
-    "pytest",
-    { replace = "posargs", extend = true, default = [
-      "--cov",
-      "{tox_root}{/}meta",
-      "--cov-config=pyproject.toml",
-      "--no-cov-on-fail",
-      "--cov-report",
-      "term-missing:skip-covered",
-      "--cov-context=test",
-      "--cov-report",
-      "html:{env_tmp_dir}{/}htmlcov",
-      "--cov-report",
-      "xml:{work_dir}{/}coverage.{env_name}.xml",
-      "--junitxml",
-      "{work_dir}{/}junit.{env_name}.xml",
-      "meta/tests",
-      "-v",
-    ] },
-  ],
-  [
-    "diff-cover",
-    "--compare-branch",
-    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
-    "{work_dir}{/}coverage.{env_name}.xml",
-    "--fail-under",
-    "100",
-  ],
-]
+base = [ "meta" ]
 
 [env."meta-3.12"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [
-  [
-    "python",
-    "-m",
-    "pytest",
-    { replace = "posargs", extend = true, default = [
-      "--cov",
-      "{tox_root}{/}meta",
-      "--cov-config=pyproject.toml",
-      "--no-cov-on-fail",
-      "--cov-report",
-      "term-missing:skip-covered",
-      "--cov-context=test",
-      "--cov-report",
-      "html:{env_tmp_dir}{/}htmlcov",
-      "--cov-report",
-      "xml:{work_dir}{/}coverage.{env_name}.xml",
-      "--junitxml",
-      "{work_dir}{/}junit.{env_name}.xml",
-      "meta/tests",
-      "-v",
-    ] },
-  ],
-  [
-    "diff-cover",
-    "--compare-branch",
-    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
-    "{work_dir}{/}coverage.{env_name}.xml",
-    "--fail-under",
-    "100",
-  ],
-]
+base = [ "meta" ]
 
 [env."meta-3.13"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [
-  [
-    "python",
-    "-m",
-    "pytest",
-    { replace = "posargs", extend = true, default = [
-      "--cov",
-      "{tox_root}{/}meta",
-      "--cov-config=pyproject.toml",
-      "--no-cov-on-fail",
-      "--cov-report",
-      "term-missing:skip-covered",
-      "--cov-context=test",
-      "--cov-report",
-      "html:{env_tmp_dir}{/}htmlcov",
-      "--cov-report",
-      "xml:{work_dir}{/}coverage.{env_name}.xml",
-      "--junitxml",
-      "{work_dir}{/}junit.{env_name}.xml",
-      "meta/tests",
-      "-v",
-    ] },
-  ],
-  [
-    "diff-cover",
-    "--compare-branch",
-    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
-    "{work_dir}{/}coverage.{env_name}.xml",
-    "--fail-under",
-    "100",
-  ],
-]
+base = [ "meta" ]
 
 [env."meta-3.14"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [
-  [
-    "python",
-    "-m",
-    "pytest",
-    { replace = "posargs", extend = true, default = [
-      "--cov",
-      "{tox_root}{/}meta",
-      "--cov-config=pyproject.toml",
-      "--no-cov-on-fail",
-      "--cov-report",
-      "term-missing:skip-covered",
-      "--cov-context=test",
-      "--cov-report",
-      "html:{env_tmp_dir}{/}htmlcov",
-      "--cov-report",
-      "xml:{work_dir}{/}coverage.{env_name}.xml",
-      "--junitxml",
-      "{work_dir}{/}junit.{env_name}.xml",
-      "meta/tests",
-      "-v",
-    ] },
-  ],
-  [
-    "diff-cover",
-    "--compare-branch",
-    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
-    "{work_dir}{/}coverage.{env_name}.xml",
-    "--fail-under",
-    "100",
-  ],
-]
+base = [ "meta" ]
 
 [env.dev]
 description = "generate a DEV environment"

--- a/tox.toml
+++ b/tox.toml
@@ -53,15 +53,37 @@ commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure" ] ]
 description = "run meta package tests to verify build and version injection"
 skip_install = true
 dependency_groups = [ "test" ]
+deps = [ "hatchling>=1.28" ]
 commands = [
   [
     "python",
     "-m",
     "pytest",
     { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
       "meta/tests",
       "-v",
     ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
   ],
 ]
 

--- a/tox.toml
+++ b/tox.toml
@@ -87,7 +87,6 @@ commands = [
   ],
 ]
 
-
 [env.pkg_meta]
 description = "check that the long description is valid"
 skip_install = true

--- a/tox.toml
+++ b/tox.toml
@@ -87,6 +87,7 @@ commands = [
   ],
 ]
 
+
 [env.pkg_meta]
 description = "check that the long description is valid"
 skip_install = true

--- a/tox.toml
+++ b/tox.toml
@@ -52,8 +52,8 @@ commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure" ] ]
 [env.meta]
 description = "run meta package tests to verify build and version injection"
 skip_install = true
-dependency_groups = [ "test" ]
 deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
 commands = [
   [
     "python",

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.34.1", "tox-uv>=1.23" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "fix", "pkg_meta", "type" ]
+env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "fix", "meta", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -48,6 +48,22 @@ description = "format the code base to adhere to our styles, and complain about 
 skip_install = true
 deps = [ "pre-commit-uv>=4.2" ]
 commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure" ] ]
+
+[env.meta]
+description = "run meta package tests to verify build and version injection"
+skip_install = true
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+]
 
 [env.pkg_meta]
 description = "check that the long description is valid"

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.34.1", "tox-uv>=1.23" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "fix", "meta-3.14", "pkg_meta", "type" ]
+env_list = [ "3.14", "meta-3.14", "3.13", "3.12", "3.11", "3.10", "fix", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -49,41 +49,6 @@ skip_install = true
 deps = [ "pre-commit-uv>=4.2" ]
 commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure" ] ]
 
-[env."meta-3.14"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
-
-[env."meta-3.13"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
-
-[env."meta-3.12"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
-
-[env."meta-3.11"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
-
-[env."meta-3.10"]
-description = "run meta package tests to verify build and version injection"
-package = "skip"
-deps = [ "hatchling>=1.28" ]
-dependency_groups = [ "test" ]
-commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
-
 [env.pkg_meta]
 description = "check that the long description is valid"
 skip_install = true
@@ -98,6 +63,196 @@ commands = [
 description = "run type check on code base"
 dependency_groups = [ "type" ]
 commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning", "." ] ]
+
+[env."meta-3.10"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
+  ],
+]
+
+[env."meta-3.11"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
+  ],
+]
+
+[env."meta-3.12"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
+  ],
+]
+
+[env."meta-3.13"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
+  ],
+]
+
+[env."meta-3.14"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [
+  [
+    "python",
+    "-m",
+    "pytest",
+    { replace = "posargs", extend = true, default = [
+      "--cov",
+      "{tox_root}{/}meta",
+      "--cov-config=pyproject.toml",
+      "--no-cov-on-fail",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-context=test",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{work_dir}{/}coverage.{env_name}.xml",
+      "--junitxml",
+      "{work_dir}{/}junit.{env_name}.xml",
+      "meta/tests",
+      "-v",
+    ] },
+  ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{work_dir}{/}coverage.{env_name}.xml",
+    "--fail-under",
+    "100",
+  ],
+]
 
 [env.dev]
 description = "generate a DEV environment"

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.34.1", "tox-uv>=1.23" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "fix", "meta", "pkg_meta", "type" ]
+env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "fix", "meta-3.14", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -49,43 +49,40 @@ skip_install = true
 deps = [ "pre-commit-uv>=4.2" ]
 commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure" ] ]
 
-[env.meta]
+[env."meta-3.14"]
 description = "run meta package tests to verify build and version injection"
-skip_install = true
+package = "skip"
 deps = [ "hatchling>=1.28" ]
 dependency_groups = [ "test" ]
-commands = [
-  [
-    "python",
-    "-m",
-    "pytest",
-    { replace = "posargs", extend = true, default = [
-      "--cov",
-      "{tox_root}{/}meta",
-      "--cov-config=pyproject.toml",
-      "--no-cov-on-fail",
-      "--cov-report",
-      "term-missing:skip-covered",
-      "--cov-context=test",
-      "--cov-report",
-      "html:{env_tmp_dir}{/}htmlcov",
-      "--cov-report",
-      "xml:{work_dir}{/}coverage.{env_name}.xml",
-      "--junitxml",
-      "{work_dir}{/}junit.{env_name}.xml",
-      "meta/tests",
-      "-v",
-    ] },
-  ],
-  [
-    "diff-cover",
-    "--compare-branch",
-    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
-    "{work_dir}{/}coverage.{env_name}.xml",
-    "--fail-under",
-    "100",
-  ],
-]
+commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
+
+[env."meta-3.13"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
+
+[env."meta-3.12"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
+
+[env."meta-3.11"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
+
+[env."meta-3.10"]
+description = "run meta package tests to verify build and version injection"
+package = "skip"
+deps = [ "hatchling>=1.28" ]
+dependency_groups = [ "test" ]
+commands = [ [ "python", "-m", "pytest", { replace = "posargs", extend = true, default = [ "--cov", "{tox_root}{/}meta", "--cov-config=pyproject.toml", "--no-cov-on-fail", "--cov-report", "term-missing:skip-covered", "--cov-context=test", "--cov-report", "html:{env_tmp_dir}{/}htmlcov", "--cov-report", "xml:{work_dir}{/}coverage.{env_name}.xml", "--junitxml", "{work_dir}{/}junit.{env_name}.xml", "meta/tests", "-v" ] } ], [ "diff-cover", "--compare-branch", { replace = "env", name = "DIFF_AGAINST", default = "origin/main" }, "{work_dir}{/}coverage.{env_name}.xml", "--fail-under", "100" ] ]
 
 [env.pkg_meta]
 description = "check that the long description is valid"


### PR DESCRIPTION
Docker users with system-installed `uv` were forced to download and bundle `uv` again when installing `tox-uv`, wasting bandwidth and storage in CI environments. 🐳 This became particularly problematic in containerized builds where `uv` is pre-installed at the system level but `pip install tox-uv` would download another copy.

The monorepo structure splits the project into `tox-uv-bare` (core plugin without `uv` dependency) and `tox-uv` (meta package that depends on `tox-uv-bare` plus `uv`). ✨ The `uv` detection logic implements a three-tier fallback: check `TOX_UV_PATH` environment variable first, then attempt to import bundled `uv` from the meta package, and finally fall back to system `uv` from `PATH`. Both packages share the same codebase and version number, with the release workflow building both on every tag.

Existing users installing `tox-uv` experience no change in behavior and continue to receive bundled `uv`. Docker users can now install `tox-uv-bare` to leverage their system `uv` installation without duplication. The fallback chain ensures graceful degradation with clear error messages when `uv` is unavailable.

Fixes #280