### PR TITLE
🐛 fix(meta): remove tox_uv namespace conflict

### DIFF
--- a/meta/__init__.py
+++ b/meta/__init__.py
@@ -1,0 +1,5 @@
+"""Meta package marker for tox-uv with bundled uv.
+
+This package provides no functionality itself - it's a dependency wrapper
+that installs both tox-uv-bare (the actual implementation) and uv (the tool).
+"""

--- a/meta/hatch_build.py
+++ b/meta/hatch_build.py
@@ -1,4 +1,3 @@
-# ruff: noqa: INP001
 from __future__ import annotations
 
 from pathlib import Path

--- a/meta/pyproject.toml
+++ b/meta/pyproject.toml
@@ -51,5 +51,5 @@ urls.Tracker = "https://github.com/tox-dev/tox-uv/issues"
 [tool.hatch]
 version.source = "vcs"
 version.raw-options.root = ".."
-build.targets.wheel.packages = [ "tox_uv" ]
+build.targets.wheel.force-include."__init__.py" = "tox_uv_meta/__init__.py"
 metadata.hooks.custom.path = "hatch_build.py"

--- a/meta/tests/test_meta_build.py
+++ b/meta/tests/test_meta_build.py
@@ -51,7 +51,13 @@ def test_uv_dependency_present(built_wheel: Path) -> None:
 
 def test_wheel_contains_placeholder_module(built_wheel: Path) -> None:
     with zipfile.ZipFile(built_wheel) as whl:
-        assert "tox_uv/__init__.py" in whl.namelist()
+        assert "tox_uv_meta/__init__.py" in whl.namelist()
+
+
+def test_wheel_does_not_contain_tox_uv_package(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as whl:
+        tox_uv_files = [name for name in whl.namelist() if name.startswith("tox_uv/")]
+        assert not tox_uv_files, f"Meta package should not contain tox_uv package, found: {tox_uv_files}"
 
 
 def test_build_hook_updates_metadata() -> None:

--- a/meta/tox_uv/__init__.py
+++ b/meta/tox_uv/__init__.py
@@ -1,1 +1,0 @@
-# Meta package for tox-uv with bundled uv


### PR DESCRIPTION
The meta `tox-uv` package was shipping `meta/tox_uv/__init__.py`, creating a namespace conflict with `tox-uv-bare`'s actual `tox_uv` package. When both packages are installed (either from upgrade or manual installation), Python's import system might find the meta package's empty `tox_uv` module before the bare package's full implementation. 🐛

This causes `ModuleNotFoundError: No module named 'tox_uv.plugin'` when tox tries to load the plugin via the entry point defined in `tox-uv-bare`.

The fix changes the meta package to ship `tox_uv_meta/__init__.py` instead, using hatchling's `force-include` to map the marker file to a non-conflicting namespace. This allows both packages to coexist safely - the meta package acts as a pure dependency wrapper without interfering with the actual implementation from `tox-uv-bare`.

Fixes #309