### PR TITLE
✨ feat(runner): add PEP 723 inline script metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ will get both the benefits (performance) or downsides (bugs) of `uv`.
   - [Installation options](#installation-options)
   - [uv discovery](#uv-discovery)
 - [tox environment types provided](#tox-environment-types-provided)
+- [PEP 723 inline script metadata](#pep-723-inline-script-metadata)
 - [uv.lock support](#uvlock-support)
   - [package](#package)
   - [extras](#extras)
@@ -87,8 +88,53 @@ This package will provide the following new tox environments:
 - `uv-venv-lock-runner` is the ID for the tox environments [runner](https://tox.wiki/en/4.12.1/config.html#runner) for
   environments using `uv.lock` (note we can’t detect the presence of the `uv.lock` file to enable this because that
   would break environments not using the lock file - such as your linter).
+- `uv-venv-pep-723` is the ID for the [PEP 723](https://peps.python.org/pep-0723/) inline script metadata runner. When
+  `tox-uv` is installed, `virtualenv-pep-723` is also transparently backed by uv.
 - `uv-venv-pep-517` is the ID for the PEP-517 packaging environment.
 - `uv-venv-cmd-builder` is the ID for the external cmd builder.
+
+## PEP 723 inline script metadata
+
+[PEP 723](https://peps.python.org/pep-0723/) lets Python scripts declare their dependencies and required Python version
+inline via comment blocks.
+
+Given a script `tools/check.py`:
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests>=2.31", "rich"]
+# ///
+
+import requests
+from rich import print
+
+print(requests.get("https://httpbin.org/get").json())
+```
+
+Configure tox to run it:
+
+```ini
+[testenv:check]
+runner = virtualenv-pep-723
+script = tools/check.py
+```
+
+When `tox-uv` is installed, `virtualenv-pep-723` is transparently backed by uv. You can also use
+`runner = uv-venv-pep-723` to explicitly request the uv-backed runner regardless of plugin installation.
+
+To disable the automatic promotion and use tox's built-in virtualenv+pip implementation, set `TOX_UV_NO_PEP723=1`.
+
+Run with `tox r -e check`. Positional arguments are forwarded: `tox r -e check -- --verbose`.
+
+To override the default command (which runs the script), set `commands` as usual:
+
+```ini
+[testenv:check]
+runner = virtualenv-pep-723
+script = tools/check.py
+commands = python -m pytest tests/
+```
 
 ## uv.lock support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = [
 dependencies = [
   "packaging>=26",
   "tomli>=2.4; python_version<'3.11'",
-  "tox<5,>=4.40",
+  "tox<5,>=4.52",
   "typing-extensions>=4.15; python_version<'3.10'",
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"

--- a/src/tox_uv/_run_pep723.py
+++ b/src/tox_uv/_run_pep723.py
@@ -1,0 +1,38 @@
+"""uv-backed PEP 723 runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tox.tox_env.python.pep723 import Pep723Mixin
+from tox.tox_env.runner import RunToxEnv
+
+from ._venv import UvVenv
+
+if TYPE_CHECKING:
+    from tox.tox_env.package import Package
+
+
+class UvVenvPep723Runner(Pep723Mixin, UvVenv, RunToxEnv):
+    @staticmethod
+    def id() -> str:
+        return "uv-venv-pep-723"
+
+    def _register_package_conf(self) -> bool:  # noqa: PLR6301
+        return False
+
+    @property
+    def _package_tox_env_type(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def _external_pkg_tox_env_type(self) -> str:
+        raise NotImplementedError
+
+    def _build_packages(self) -> list[Package]:  # noqa: PLR6301
+        return []
+
+
+__all__ = [
+    "UvVenvPep723Runner",
+]

--- a/src/tox_uv/_run_pep723.py
+++ b/src/tox_uv/_run_pep723.py
@@ -29,8 +29,8 @@ class UvVenvPep723Runner(Pep723Mixin, UvVenv, RunToxEnv):
     def _external_pkg_tox_env_type(self) -> str:
         raise NotImplementedError
 
-    def _build_packages(self) -> list[Package]:  # noqa: PLR6301
-        return []
+    def _build_packages(self) -> list[Package]:
+        raise NotImplementedError
 
 
 __all__ = [

--- a/src/tox_uv/plugin.py
+++ b/src/tox_uv/plugin.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import os
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
+from tox.config.loader.str_convert import StrConvert
 from tox.plugin import impl
 
 from ._package import UvVenvCmdBuilder, UvVenvPep517Packager
 from ._run import UvVenvRunner
 from ._run_lock import UvVenvLockRunner
+from ._run_pep723 import UvVenvPep723Runner
 
 if TYPE_CHECKING:
     from tox.config.cli.parser import ToxParser
@@ -20,6 +23,9 @@ if TYPE_CHECKING:
 def tox_register_tox_env(register: ToxEnvRegister) -> None:
     register.add_run_env(UvVenvRunner)
     register.add_run_env(UvVenvLockRunner)
+    register.add_run_env(UvVenvPep723Runner)
+    if not StrConvert.to_bool(os.environ.get("TOX_UV_NO_PEP723", "false")):
+        register._run_envs["virtualenv-pep-723"] = UvVenvPep723Runner  # noqa: SLF001
     register.add_package_env(UvVenvPep517Packager)
     register.add_package_env(UvVenvCmdBuilder)
     register._default_run_env = UvVenvRunner.id()  # noqa: SLF001

--- a/tests/test_tox_uv_pep723.py
+++ b/tests/test_tox_uv_pep723.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,57 +14,67 @@ from tox_uv.plugin import tox_register_tox_env
 if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator
 
+_PY_VER = f"{sys.version_info.major}.{sys.version_info.minor}"
 
-def _tox_ini(extra: str = "") -> str:
-    lines = ["[testenv:check]", "runner = uv-venv-pep-723", "script = check.py"]
+_SCRIPT_WITH_DEPS = dedent("""\
+    # /// script
+    # dependencies = ["setuptools"]
+    # ///
+    print('ok')
+""")
+
+_SCRIPT_REQUIRES_PYTHON = dedent(f"""\
+    # /// script
+    # requires-python = ">={_PY_VER}"
+    # ///
+    print("ok")
+""")
+
+_SCRIPT_BARE = 'print("ok")\n'
+
+
+def _tox_ini(runner: str = "uv-venv-pep-723", extra: str = "") -> str:
+    lines = ["[testenv:check]", f"runner = {runner}", "script = check.py"]
     if extra:
         lines.append(extra)
     return "\n".join(lines) + "\n"
 
 
-def _py_ver() -> str:
-    return f"{sys.version_info.major}.{sys.version_info.minor}"
+def _run(project: ToxProjectCreator, files: dict[str, str], *extra_args: str) -> tuple:
+    proj = project(files)
+    execute_calls = proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = proj.run("r", "-e", "check", "--discover", sys.executable, *extra_args)
+    return result, execute_calls
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_deps_installed(tox_project: ToxProjectCreator) -> None:
-    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_WITH_DEPS})
     result.assert_success()
     install_cmds = [i[0][3].cmd for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
     assert any("setuptools" in arg for cmd in install_cmds for arg in cmd)
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_no_deps_when_only_requires_python(tox_project: ToxProjectCreator) -> None:
-    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\nprint("ok")\n'
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
-    result.assert_success()
-    assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
-
-
-@pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_no_deps_when_no_metadata(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": 'print("ok")\n'})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+@pytest.mark.parametrize(
+    ("script", "test_id"),
+    [
+        pytest.param(_SCRIPT_REQUIRES_PYTHON, "only-requires-python", id="only-requires-python"),
+        pytest.param(_SCRIPT_BARE, "no-metadata", id="no-metadata"),
+    ],
+)
+def test_no_deps_installed(tox_project: ToxProjectCreator, script: str, test_id: str) -> None:  # noqa: ARG001
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_success()
     assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_custom_commands_override(tox_project: ToxProjectCreator) -> None:
-    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
-    project = tox_project({
-        "tox.ini": _tox_ini("commands = python -c \"print('custom')\""),
-        "check.py": script,
-    })
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result, execute_calls = _run(
+        tox_project,
+        {"tox.ini": _tox_ini(extra="commands = python -c \"print('custom')\""), "check.py": _SCRIPT_WITH_DEPS},
+    )
     result.assert_success()
     cmd_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]"]
     assert any("custom" in str(cmd) for cmd in cmd_calls)
@@ -71,9 +82,7 @@ def test_custom_commands_override(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_default_commands_forward_posargs(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": 'print("ok")\n'})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable, "--", "arg1", "arg2")
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_BARE}, "--", "arg1", "arg2")
     result.assert_success()
     cmd = next(i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]")
     assert "arg1" in cmd
@@ -82,59 +91,61 @@ def test_default_commands_forward_posargs(tox_project: ToxProjectCreator) -> Non
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_requires_python_satisfied(tox_project: ToxProjectCreator) -> None:
-    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\nprint("ok")\n'
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result, _ = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_REQUIRES_PYTHON})
     result.assert_success()
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_requires_python_not_satisfied(tox_project: ToxProjectCreator) -> None:
-    script = '# /// script\n# requires-python = ">=99.0"\n# ///\nprint("ok")\n'
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    script = dedent("""\
+        # /// script
+        # requires-python = ">=99.0"
+        # ///
+        print("ok")
+    """)
+    result, _ = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_failed()
     assert "does not satisfy requires-python" in result.out
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_skip_env_install(tox_project: ToxProjectCreator) -> None:
-    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable, "--skip-env-install")
+    result, execute_calls = _run(
+        tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_WITH_DEPS}, "--skip-env-install"
+    )
     result.assert_success()
     assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_missing_script_file(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({"tox.ini": _tox_ini()})
-    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result, _ = _run(tox_project, {"tox.ini": _tox_ini()})
     result.assert_failed()
     assert "script file not found" in result.out
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_base_python_rejected(tox_project: ToxProjectCreator) -> None:
-    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\n'
-    project = tox_project({"tox.ini": _tox_ini("base_python = python3"), "check.py": script})
-    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result, _ = _run(
+        tox_project,
+        {"tox.ini": _tox_ini(extra="base_python = python3"), "check.py": _SCRIPT_REQUIRES_PYTHON},
+    )
     result.assert_failed()
     assert "cannot set base_python" in result.out
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_virtualenv_pep723_promoted_to_uv(tox_project: ToxProjectCreator) -> None:
-    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
-    ini = "[testenv:check]\nrunner = virtualenv-pep-723\nscript = check.py\n"
-    project = tox_project({"tox.ini": ini, "check.py": script})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable, "-vv")
+@pytest.mark.parametrize(
+    "runner",
+    [
+        pytest.param("uv-venv-pep-723", id="explicit"),
+        pytest.param("virtualenv-pep-723", id="promoted"),
+    ],
+)
+def test_uses_uv_venv(tox_project: ToxProjectCreator, runner: str) -> None:
+    result, execute_calls = _run(
+        tox_project, {"tox.ini": _tox_ini(runner=runner), "check.py": _SCRIPT_WITH_DEPS}, "-vv"
+    )
     result.assert_success()
     venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
     assert venv_calls
@@ -142,30 +153,22 @@ def test_virtualenv_pep723_promoted_to_uv(tox_project: ToxProjectCreator) -> Non
     assert venv_calls[0][1] == "venv"
 
 
-def test_no_pep723_promotion_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TOX_UV_NO_PEP723", "1")
+@pytest.mark.parametrize(
+    ("env_val", "promoted"),
+    [
+        pytest.param(None, True, id="default"),
+        pytest.param("1", False, id="disabled"),
+    ],
+)
+def test_pep723_promotion_env_var(monkeypatch: pytest.MonkeyPatch, env_val: str | None, promoted: bool) -> None:
+    if env_val is None:
+        monkeypatch.delenv("TOX_UV_NO_PEP723", raising=False)
+    else:
+        monkeypatch.setenv("TOX_UV_NO_PEP723", env_val)
     register = ToxEnvRegister()
     tox_register_tox_env(register)
     assert register._run_envs["uv-venv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
-    assert register._run_envs.get("virtualenv-pep-723") is None  # noqa: SLF001
-
-
-def test_pep723_promotion_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("TOX_UV_NO_PEP723", raising=False)
-    register = ToxEnvRegister()
-    tox_register_tox_env(register)
-    assert register._run_envs["uv-venv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
-    assert register._run_envs["virtualenv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
-
-
-@pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_uses_uv_venv(tox_project: ToxProjectCreator) -> None:
-    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
-    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
-    result = project.run("r", "-e", "check", "--discover", sys.executable, "-vv")
-    result.assert_success()
-    venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
-    assert venv_calls
-    assert Path(venv_calls[0][0]).stem == "uv"
-    assert venv_calls[0][1] == "venv"
+    if promoted:
+        assert register._run_envs["virtualenv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
+    else:
+        assert register._run_envs.get("virtualenv-pep-723") is None  # noqa: SLF001

--- a/tests/test_tox_uv_pep723.py
+++ b/tests/test_tox_uv_pep723.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+from tox.tox_env.register import ToxEnvRegister
+
+from tox_uv._run_pep723 import UvVenvPep723Runner
+from tox_uv.plugin import tox_register_tox_env
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def _tox_ini(extra: str = "") -> str:
+    lines = ["[testenv:check]", "runner = uv-venv-pep-723", "script = check.py"]
+    if extra:
+        lines.append(extra)
+    return "\n".join(lines) + "\n"
+
+
+def _py_ver() -> str:
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_deps_installed(tox_project: ToxProjectCreator) -> None:
+    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_success()
+    install_cmds = [i[0][3].cmd for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
+    assert any("setuptools" in arg for cmd in install_cmds for arg in cmd)
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_no_deps_when_only_requires_python(tox_project: ToxProjectCreator) -> None:
+    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\nprint("ok")\n'
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_success()
+    assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_no_deps_when_no_metadata(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": 'print("ok")\n'})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_success()
+    assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_custom_commands_override(tox_project: ToxProjectCreator) -> None:
+    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
+    project = tox_project({
+        "tox.ini": _tox_ini("commands = python -c \"print('custom')\""),
+        "check.py": script,
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_success()
+    cmd_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]"]
+    assert any("custom" in str(cmd) for cmd in cmd_calls)
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_default_commands_forward_posargs(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": 'print("ok")\n'})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable, "--", "arg1", "arg2")
+    result.assert_success()
+    cmd = next(i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]")
+    assert "arg1" in cmd
+    assert "arg2" in cmd
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_requires_python_satisfied(tox_project: ToxProjectCreator) -> None:
+    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\nprint("ok")\n'
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_success()
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_requires_python_not_satisfied(tox_project: ToxProjectCreator) -> None:
+    script = '# /// script\n# requires-python = ">=99.0"\n# ///\nprint("ok")\n'
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "does not satisfy requires-python" in result.out
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_skip_env_install(tox_project: ToxProjectCreator) -> None:
+    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable, "--skip-env-install")
+    result.assert_success()
+    assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_missing_script_file(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": _tox_ini()})
+    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "script file not found" in result.out
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_base_python_rejected(tox_project: ToxProjectCreator) -> None:
+    script = f'# /// script\n# requires-python = ">={_py_ver()}"\n# ///\n'
+    project = tox_project({"tox.ini": _tox_ini("base_python = python3"), "check.py": script})
+    project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "cannot set base_python" in result.out
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_virtualenv_pep723_promoted_to_uv(tox_project: ToxProjectCreator) -> None:
+    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
+    ini = "[testenv:check]\nrunner = virtualenv-pep-723\nscript = check.py\n"
+    project = tox_project({"tox.ini": ini, "check.py": script})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable, "-vv")
+    result.assert_success()
+    venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
+    assert venv_calls
+    assert venv_calls[0][0].endswith("uv")
+    assert venv_calls[0][1] == "venv"
+
+
+def test_no_pep723_promotion_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOX_UV_NO_PEP723", "1")
+    register = ToxEnvRegister()
+    tox_register_tox_env(register)
+    assert register._run_envs["uv-venv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
+    assert register._run_envs.get("virtualenv-pep-723") is None  # noqa: SLF001
+
+
+def test_pep723_promotion_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TOX_UV_NO_PEP723", raising=False)
+    register = ToxEnvRegister()
+    tox_register_tox_env(register)
+    assert register._run_envs["uv-venv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
+    assert register._run_envs["virtualenv-pep-723"] is UvVenvPep723Runner  # noqa: SLF001
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_uses_uv_venv(tox_project: ToxProjectCreator) -> None:
+    script = "# /// script\n# dependencies = [\"setuptools\"]\n# ///\nprint('ok')\n"
+    project = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = project.run("r", "-e", "check", "--discover", sys.executable, "-vv")
+    result.assert_success()
+    venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
+    assert venv_calls
+    assert venv_calls[0][0].endswith("uv")
+    assert venv_calls[0][1] == "venv"

--- a/tests/test_tox_uv_pep723.py
+++ b/tests/test_tox_uv_pep723.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -137,7 +138,7 @@ def test_virtualenv_pep723_promoted_to_uv(tox_project: ToxProjectCreator) -> Non
     result.assert_success()
     venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
     assert venv_calls
-    assert venv_calls[0][0].endswith("uv")
+    assert Path(venv_calls[0][0]).stem == "uv"
     assert venv_calls[0][1] == "venv"
 
 
@@ -166,5 +167,5 @@ def test_uses_uv_venv(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
     venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
     assert venv_calls
-    assert venv_calls[0][0].endswith("uv")
+    assert Path(venv_calls[0][0]).stem == "uv"
     assert venv_calls[0][1] == "venv"

--- a/tests/test_tox_uv_pep723.py
+++ b/tests/test_tox_uv_pep723.py
@@ -14,24 +14,6 @@ from tox_uv.plugin import tox_register_tox_env
 if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator
 
-_PY_VER = f"{sys.version_info.major}.{sys.version_info.minor}"
-
-_SCRIPT_WITH_DEPS = dedent("""\
-    # /// script
-    # dependencies = ["setuptools"]
-    # ///
-    print('ok')
-""")
-
-_SCRIPT_REQUIRES_PYTHON = dedent(f"""\
-    # /// script
-    # requires-python = ">={_PY_VER}"
-    # ///
-    print("ok")
-""")
-
-_SCRIPT_BARE = 'print("ok")\n'
-
 
 def _tox_ini(runner: str = "uv-venv-pep-723", extra: str = "") -> str:
     lines = ["[testenv:check]", f"runner = {runner}", "script = check.py"]
@@ -49,7 +31,13 @@ def _run(project: ToxProjectCreator, files: dict[str, str], *extra_args: str) ->
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_deps_installed(tox_project: ToxProjectCreator) -> None:
-    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_WITH_DEPS})
+    script = dedent("""\
+        # /// script
+        # dependencies = ["setuptools"]
+        # ///
+        print('ok')
+    """)
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_success()
     install_cmds = [i[0][3].cmd for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
     assert any("setuptools" in arg for cmd in install_cmds for arg in cmd)
@@ -57,13 +45,21 @@ def test_deps_installed(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 @pytest.mark.parametrize(
-    ("script", "test_id"),
+    "script",
     [
-        pytest.param(_SCRIPT_REQUIRES_PYTHON, "only-requires-python", id="only-requires-python"),
-        pytest.param(_SCRIPT_BARE, "no-metadata", id="no-metadata"),
+        pytest.param(
+            dedent(f"""\
+                # /// script
+                # requires-python = ">={sys.version_info.major}.{sys.version_info.minor}"
+                # ///
+                print("ok")
+            """),
+            id="only-requires-python",
+        ),
+        pytest.param('print("ok")\n', id="no-metadata"),
     ],
 )
-def test_no_deps_installed(tox_project: ToxProjectCreator, script: str, test_id: str) -> None:  # noqa: ARG001
+def test_no_deps_installed(tox_project: ToxProjectCreator, script: str) -> None:
     result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_success()
     assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
@@ -71,9 +67,15 @@ def test_no_deps_installed(tox_project: ToxProjectCreator, script: str, test_id:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_custom_commands_override(tox_project: ToxProjectCreator) -> None:
+    script = dedent("""\
+        # /// script
+        # dependencies = ["setuptools"]
+        # ///
+        print('ok')
+    """)
     result, execute_calls = _run(
         tox_project,
-        {"tox.ini": _tox_ini(extra="commands = python -c \"print('custom')\""), "check.py": _SCRIPT_WITH_DEPS},
+        {"tox.ini": _tox_ini(extra="commands = python -c \"print('custom')\""), "check.py": script},
     )
     result.assert_success()
     cmd_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]"]
@@ -82,7 +84,9 @@ def test_custom_commands_override(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_default_commands_forward_posargs(tox_project: ToxProjectCreator) -> None:
-    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_BARE}, "--", "arg1", "arg2")
+    result, execute_calls = _run(
+        tox_project, {"tox.ini": _tox_ini(), "check.py": 'print("ok")\n'}, "--", "arg1", "arg2"
+    )
     result.assert_success()
     cmd = next(i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "commands[0]")
     assert "arg1" in cmd
@@ -91,7 +95,13 @@ def test_default_commands_forward_posargs(tox_project: ToxProjectCreator) -> Non
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_requires_python_satisfied(tox_project: ToxProjectCreator) -> None:
-    result, _ = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_REQUIRES_PYTHON})
+    script = dedent(f"""\
+        # /// script
+        # requires-python = ">={sys.version_info.major}.{sys.version_info.minor}"
+        # ///
+        print("ok")
+    """)
+    result, _ = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_success()
 
 
@@ -110,9 +120,13 @@ def test_requires_python_not_satisfied(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_skip_env_install(tox_project: ToxProjectCreator) -> None:
-    result, execute_calls = _run(
-        tox_project, {"tox.ini": _tox_ini(), "check.py": _SCRIPT_WITH_DEPS}, "--skip-env-install"
-    )
+    script = dedent("""\
+        # /// script
+        # dependencies = ["setuptools"]
+        # ///
+        print('ok')
+    """)
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script}, "--skip-env-install")
     result.assert_success()
     assert not [i for i in execute_calls.call_args_list if "install" in i[0][3].run_id]
 
@@ -126,9 +140,14 @@ def test_missing_script_file(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_base_python_rejected(tox_project: ToxProjectCreator) -> None:
+    script = dedent(f"""\
+        # /// script
+        # requires-python = ">={sys.version_info.major}.{sys.version_info.minor}"
+        # ///
+    """)
     result, _ = _run(
         tox_project,
-        {"tox.ini": _tox_ini(extra="base_python = python3"), "check.py": _SCRIPT_REQUIRES_PYTHON},
+        {"tox.ini": _tox_ini(extra="base_python = python3"), "check.py": script},
     )
     result.assert_failed()
     assert "cannot set base_python" in result.out
@@ -143,9 +162,13 @@ def test_base_python_rejected(tox_project: ToxProjectCreator) -> None:
     ],
 )
 def test_uses_uv_venv(tox_project: ToxProjectCreator, runner: str) -> None:
-    result, execute_calls = _run(
-        tox_project, {"tox.ini": _tox_ini(runner=runner), "check.py": _SCRIPT_WITH_DEPS}, "-vv"
-    )
+    script = dedent("""\
+        # /// script
+        # dependencies = ["setuptools"]
+        # ///
+        print('ok')
+    """)
+    result, execute_calls = _run(tox_project, {"tox.ini": _tox_ini(runner=runner), "check.py": script}, "-vv")
     result.assert_success()
     venv_calls = [i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "venv"]
     assert venv_calls


### PR DESCRIPTION
tox 4.52 introduced `Pep723Mixin` for running standalone Python scripts with inline dependency declarations ([PEP 723](https://peps.python.org/pep-0723/)). This composes `Pep723Mixin` with `UvVenv` and `RunToxEnv` so PEP 723 scripts benefit from uv's faster venv creation and package installation.

When `tox-uv` is installed, `virtualenv-pep-723` is automatically promoted to the uv-backed implementation. ✨ Users can also explicitly request it via `runner = uv-venv-pep-723`. To opt out of the automatic promotion, set `TOX_UV_NO_PEP723=1` to fall back to tox's built-in virtualenv+pip runner.

The tox minimum version is bumped to `>=4.52` since that's where `Pep723Mixin` was added.