### PR TITLE
🐛 fix(installer): invalidate install cache on UV_* env var changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,4 +292,17 @@ are combined into a single install operation. This ensures the resolution strate
 requirements, preventing sequential installations from resolving transitive dependencies before the strategy can apply
 to overlapping direct dependencies.
 
+### Cache invalidation for `UV_*` environment variables
+
+tox-uv includes a curated set of `UV_*` environment variables in the install cache key. When any of these variables
+change via `set_env`, the cached environment is invalidated and packages are reinstalled so that uv can re-resolve with
+the new settings. The tracked variables are:
+
+`UV_CONSTRAINT`, `UV_DEFAULT_INDEX`, `UV_EXCLUDE`, `UV_EXCLUDE_NEWER`, `UV_EXTRA_INDEX_URL`, `UV_FIND_LINKS`,
+`UV_FORK_STRATEGY`, `UV_INDEX`, `UV_INDEX_STRATEGY`, `UV_INDEX_URL`, `UV_KEYRING_PROVIDER`, `UV_NO_INDEX`,
+`UV_NO_SOURCES`, `UV_OFFLINE`, `UV_OVERRIDE`, `UV_PRERELEASE`, `UV_REQUIRE_HASHES`, `UV_RESOLUTION`, `UV_TORCH_BACKEND`.
+
+Variables that do not affect resolution (e.g. `UV_CONCURRENT_DOWNLOADS`, `UV_NO_PROGRESS`, `UV_CACHE_DIR`) are not
+tracked and changing them will not trigger a reinstall.
+
 [resolution strategy]: https://github.com/astral-sh/uv/blob/0.1.20/README.md#resolution-strategy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = [
 dependencies = [
   "packaging>=26",
   "tomli>=2.4; python_version<'3.11'",
-  "tox<5,>=4.52",
+  "tox<5,>=4.52.1",
   "typing-extensions>=4.15; python_version<'3.10'"
 ]
 urls.Changelog = "https://github.com/tox-dev/tox-uv/releases"

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -66,9 +66,6 @@ class UvInstaller(Pip):
         self._with_list_deps = with_list_deps
         super().__init__(tox_env)
 
-    def _install_env_vars(self) -> dict[str, str]:
-        return {k: v for k, v in self._env.environment_variables.items() if k in _UV_RESOLUTION_ENV_VARS}
-
     def freeze_cmd(self) -> list[str]:
         return [self.uv, "--color", "never", "pip", "freeze"]
 
@@ -210,6 +207,9 @@ class UvInstaller(Pip):
             for entry in groups["dev_pkg"]:
                 install_args.extend(("-e", str(entry)))
             self._execute_installer(install_args, of_type)
+
+    def _install_env_vars(self) -> dict[str, str]:
+        return {k: v for k, v in self._env.environment_variables.items() if k in _UV_RESOLUTION_ENV_VARS}
 
 
 __all__ = [

--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -33,6 +33,28 @@ if TYPE_CHECKING:
 
 _LOGGER: Final[logging.Logger] = logging.getLogger(__name__)
 
+_UV_RESOLUTION_ENV_VARS: frozenset[str] = frozenset({
+    "UV_CONSTRAINT",
+    "UV_DEFAULT_INDEX",
+    "UV_EXCLUDE",
+    "UV_EXCLUDE_NEWER",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "UV_FORK_STRATEGY",
+    "UV_INDEX",
+    "UV_INDEX_STRATEGY",
+    "UV_INDEX_URL",
+    "UV_KEYRING_PROVIDER",
+    "UV_NO_INDEX",
+    "UV_NO_SOURCES",
+    "UV_OFFLINE",
+    "UV_OVERRIDE",
+    "UV_PRERELEASE",
+    "UV_REQUIRE_HASHES",
+    "UV_RESOLUTION",
+    "UV_TORCH_BACKEND",
+})
+
 
 class UvInstaller(Pip):
     """Pip is a python installer that can install packages as defined by PEP-508 and PEP-517."""
@@ -43,6 +65,9 @@ class UvInstaller(Pip):
     def __init__(self, tox_env: UvVenv, with_list_deps: bool = True) -> None:  # noqa: FBT001, FBT002
         self._with_list_deps = with_list_deps
         super().__init__(tox_env)
+
+    def _install_env_vars(self) -> dict[str, str]:
+        return {k: v for k, v in self._env.environment_variables.items() if k in _UV_RESOLUTION_ENV_VARS}
 
     def freeze_cmd(self) -> list[str]:
         return [self.uv, "--color", "never", "pip", "freeze"]
@@ -161,13 +186,15 @@ class UvInstaller(Pip):
         req_of_type = f"{of_type}_deps" if groups["pkg"] or groups["dev_pkg"] else of_type
         for value in groups.values():
             value.sort()
-        with self._env.cache.compare(groups["req"], section, req_of_type) as (eq, old):
+        cache_value = {"req": groups["req"], "env": self._install_env_vars()}
+        with self._env.cache.compare(cache_value, section, req_of_type) as (eq, old):
             if not eq:  # pragma: no branch
-                miss = sorted(set(old or []) - set(groups["req"]))
-                if miss:  # no way yet to know what to uninstall here (transitive dependencies?) # pragma: no branch
+                old_req: list[str] = old["req"] if isinstance(old, dict) else (old or [])
+                miss = sorted(set(old_req) - set(groups["req"]))
+                if miss:  # no way yet to know what to uninstall here (transitive dependencies?)  # pragma: no branch
                     msg = f"dependencies removed: {', '.join(str(i) for i in miss)}"  # pragma: no cover
-                    raise Recreate(msg)  # pragma: no branch                     # pragma: no cover
-                new_deps = sorted(set(groups["req"]) - set(old or []))
+                    raise Recreate(msg)  # pragma: no cover
+                new_deps = sorted(set(groups["req"]) - set(old_req)) or list(groups["req"])
                 if new_deps:  # pragma: no branch
                     self._execute_installer(new_deps, req_of_type)
         install_args = ["--reinstall"]

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    from tox.execute.request import ExecuteRequest
     from tox.pytest import ToxProjectCreator
 
 
@@ -256,12 +257,21 @@ def test_uv_resolution_env_var_change_reinstalls(tox_project: ToxProjectCreator)
                 package = skip
             """,
     })
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    install_count = 0
+
+    def handle(r: ExecuteRequest) -> int | None:
+        nonlocal install_count
+        if "install" in r.run_id:
+            install_count += 1
+            return 0
+        return None
+
+    project.patch_execute(handle)
 
     result = project.run("r")
     result.assert_success()
-    assert execute_calls.call_count == 1
-    execute_calls.reset_mock()
+    assert install_count == 1
+    install_count = 0
 
     (project.path / "tox.ini").write_text(
         dedent("""
@@ -273,7 +283,7 @@ def test_uv_resolution_env_var_change_reinstalls(tox_project: ToxProjectCreator)
     )
     result = project.run("r")
     result.assert_success()
-    assert execute_calls.call_count == 1
+    assert install_count == 1
 
 
 def test_uv_non_resolution_env_var_change_no_reinstall(tox_project: ToxProjectCreator) -> None:
@@ -285,12 +295,21 @@ def test_uv_non_resolution_env_var_change_no_reinstall(tox_project: ToxProjectCr
                 setenv = UV_CONCURRENT_DOWNLOADS = 4
             """,
     })
-    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    install_count = 0
+
+    def handle(r: ExecuteRequest) -> int | None:
+        nonlocal install_count
+        if "install" in r.run_id:
+            install_count += 1
+            return 0
+        return None
+
+    project.patch_execute(handle)
 
     result = project.run("r")
     result.assert_success()
-    assert execute_calls.call_count == 1
-    execute_calls.reset_mock()
+    assert install_count == 1
+    install_count = 0
 
     (project.path / "tox.ini").write_text(
         dedent("""
@@ -302,7 +321,7 @@ def test_uv_non_resolution_env_var_change_no_reinstall(tox_project: ToxProjectCr
     )
     result = project.run("r")
     result.assert_success()
-    assert execute_calls.call_count == 0
+    assert install_count == 0
 
 
 def test_uv_install_broken_venv(tox_project: ToxProjectCreator) -> None:

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -245,6 +246,63 @@ version = "0.1.0"
     result = project.run("-vv")
     result.assert_failed()
     assert "uv cannot install" in result.out
+
+
+def test_uv_resolution_env_var_change_reinstalls(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+                [testenv]
+                deps = tomli
+                package = skip
+            """,
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+
+    result = project.run("r")
+    result.assert_success()
+    assert execute_calls.call_count == 1
+    execute_calls.reset_mock()
+
+    (project.path / "tox.ini").write_text(
+        dedent("""
+            [testenv]
+            deps = tomli
+            package = skip
+            setenv = UV_EXCLUDE_NEWER = 2024-01-01
+        """)
+    )
+    result = project.run("r")
+    result.assert_success()
+    assert execute_calls.call_count == 1
+
+
+def test_uv_non_resolution_env_var_change_no_reinstall(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+                [testenv]
+                deps = tomli
+                package = skip
+                setenv = UV_CONCURRENT_DOWNLOADS = 4
+            """,
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+
+    result = project.run("r")
+    result.assert_success()
+    assert execute_calls.call_count == 1
+    execute_calls.reset_mock()
+
+    (project.path / "tox.ini").write_text(
+        dedent("""
+            [testenv]
+            deps = tomli
+            package = skip
+            setenv = UV_CONCURRENT_DOWNLOADS = 8
+        """)
+    )
+    result = project.run("r")
+    result.assert_success()
+    assert execute_calls.call_count == 0
 
 
 def test_uv_install_broken_venv(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
Setting a resolution-affecting `UV_*` env var via `set_env` (e.g. `UV_EXCLUDE_NEWER`) had no effect on an already-cached environment. The install cache key only tracked the requirements list, so a user switching between runs with and without a date cutoff would silently get stale packages. Reported in tox-dev/tox#3917; the tox-side fix exposing the extension point landed in tox-dev/tox#3921.

`UvInstaller` now overrides `_install_env_vars()` from tox's `Pip` base class, returning the subset of `UV_*` vars known to affect resolution: index URLs, exclusion filters, resolution strategy, pre-release policy, constraints, overrides, and keyring provider. 🐛 Cosmetic and performance vars (`UV_CONCURRENT_DOWNLOADS`, `UV_NO_PROGRESS`, etc.) are excluded to avoid spurious reinstalls.

On the first run after upgrading, existing environments see a one-time reinstall as the cache format gains an `"env"` key. Requires tox>=4.52.1 for the `_install_env_vars()` extension point.