### PR TITLE
fix(lock-runner): respect UV_FROZEN env var and --frozen in uv_sync_flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,26 @@ installed into the environment you can do:
 uv_sync_flags = --no-editable, --inexact
 ```
 
+If `--frozen` is included in `uv_sync_flags`, tox-uv will automatically suppress the implicit `--locked` argument
+since the two flags are mutually exclusive in uv:
+
+```ini
+uv_sync_flags = --frozen
+```
+
 ### `uv_sync_locked`
 
 By default tox-uv will call `uv sync` with `--locked` argument, which is incompatible with other arguments like
 `--prerelease` or `--upgrade ` that you might want to add to `uv_sync_flags` for some test scenarios. You can set this
 to `false` to avoid such conflicts.
+
+If the `UV_FROZEN` environment variable is set to a truthy value, tox-uv will automatically suppress `--locked` and
+pass `--frozen` to `uv sync` instead. This is useful in CI environments where the lockfile was created on a different
+platform and platform-specific metadata validation should be skipped:
+
+```bash
+UV_FROZEN=1 tox
+```
 
 ### External package support
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ installed into the environment you can do:
 uv_sync_flags = --no-editable, --inexact
 ```
 
-If `--frozen` is included in `uv_sync_flags`, tox-uv will automatically suppress the implicit `--locked` argument
-since the two flags are mutually exclusive in uv:
+If `--frozen` is included in `uv_sync_flags`, tox-uv will automatically suppress the implicit `--locked` argument since
+the two flags are mutually exclusive in uv:
 
 ```ini
 uv_sync_flags = --frozen
@@ -246,8 +246,8 @@ By default tox-uv will call `uv sync` with `--locked` argument, which is incompa
 `--prerelease` or `--upgrade ` that you might want to add to `uv_sync_flags` for some test scenarios. You can set this
 to `false` to avoid such conflicts.
 
-If the `UV_FROZEN` environment variable is set to a truthy value, tox-uv will automatically suppress `--locked` and
-pass `--frozen` to `uv sync` instead. This is useful in CI environments where the lockfile was created on a different
+If the `UV_FROZEN` environment variable is set to a truthy value, tox-uv will automatically suppress `--locked` and pass
+`--frozen` to `uv sync` instead. This is useful in CI environments where the lockfile was created on a different
 platform and platform-specific metadata validation should be skipped:
 
 ```bash

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -104,7 +104,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
                 cmd.extend(("--directory", str(package_root)))
             env_vars = self.environment_variables
             uv_frozen_val = env_vars.get("UV_FROZEN", "")
-            uv_frozen = uv_frozen_val.lower() not in ("", "0", "false", "no", "off")
+            uv_frozen = uv_frozen_val.lower() not in {"", "0", "false", "no", "off"}
             frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
             if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
                 cmd.append("--locked")

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -102,8 +102,14 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             ]
             if package_root != self.core["tox_root"]:
                 cmd.extend(("--directory", str(package_root)))
-            if self.conf["uv_sync_locked"]:
+            env_vars = self.environment_variables
+            uv_frozen_val = env_vars.get("UV_FROZEN", "")
+            uv_frozen = uv_frozen_val.lower() not in ("", "0", "false", "no", "off")
+            frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
+            if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
                 cmd.append("--locked")
+            elif uv_frozen and not frozen_in_flags:
+                cmd.append("--frozen")
             if self.conf["uv_python_preference"] != "none":
                 cmd.extend(("--python-preference", self.conf["uv_python_preference"]))
             if self.conf["uv_resolution"]:

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -89,59 +89,11 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         )
         add_skip_missing_interpreters_to_core(self.core, self.options)
 
-    def _setup_env(self) -> None:  # noqa: C901,PLR0912,PLR0914,PLR0915
+    def _setup_env(self) -> None:
         super()._setup_env()
         install_pkg = getattr(self.options, "install_pkg", None)
         if not getattr(self.options, "skip_uv_sync", False):
-            package_root: Path = self.conf["package_root"]
-            if not package_root.is_absolute():
-                package_root = self.core["tox_root"] / package_root
-            cmd = [
-                self.uv,
-                "sync",
-            ]
-            if package_root != self.core["tox_root"]:
-                cmd.extend(("--directory", str(package_root)))
-            env_vars = self.environment_variables
-            uv_frozen_val = env_vars.get("UV_FROZEN", "")
-            uv_frozen = uv_frozen_val.lower() not in {"", "0", "false", "no", "off"}
-            frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
-            if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
-                cmd.append("--locked")
-            if uv_frozen and not frozen_in_flags:
-                cmd.append("--frozen")
-            if self.conf["uv_python_preference"] != "none":
-                cmd.extend(("--python-preference", self.conf["uv_python_preference"]))
-            if self.conf["uv_resolution"]:
-                cmd.extend(("--resolution", self.conf["uv_resolution"]))
-            for extra in cast("set[str]", sorted(self.conf["extras"])):
-                cmd.extend(("--extra", extra))
-            groups = sorted(self.conf["dependency_groups"])
-            if self.conf["no_default_groups"]:
-                cmd.append("--no-default-groups")
-            package = self.conf["package"]
-            if install_pkg is not None or package == "skip":
-                cmd.append("--no-install-project")
-            if self.options.verbosity > 3:  # noqa: PLR2004
-                cmd.append("-v")
-            if package in {"wheel", "uv"}:
-                project_file = package_root / "pyproject.toml"
-                name = None
-                if project_file.exists():
-                    with project_file.open("rb") as file_handler:
-                        raw = tomllib.load(file_handler)
-                    name = raw.get("project", {}).get("name")
-                if name is None:
-                    msg = "Could not detect project name"
-                    raise HandledError(msg)
-                cmd.extend(("--no-editable", "--reinstall-package", name))
-            for group in groups:
-                cmd.extend(("--group", group))
-            for group in sorted(self.conf["only_groups"]):
-                cmd.extend(("--only-group", group))
-            cmd.extend(self.conf["uv_sync_flags"])
-            cmd.extend(("-p", self.env_version_spec()))
-
+            cmd = self._build_uv_sync_cmd(install_pkg)
             show = self.options.verbosity > 2  # noqa: PLR2004
             outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=show)
             outcome.assert_success()
@@ -150,11 +102,70 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             pkg = (WheelPackage if path.suffix == ".whl" else SdistPackage)(path, deps=[])
             self._install([pkg], "install-pkg", of_type="external")
 
+    def _build_uv_sync_cmd(self, install_pkg: str | None) -> list[str]:
+        package_root = self._resolved_package_root()
+        cmd = [self.uv, "sync"]
+        if package_root != self.core["tox_root"]:
+            cmd.extend(("--directory", str(package_root)))
+        self._add_lock_flags(cmd)
+        if self.conf["uv_python_preference"] != "none":
+            cmd.extend(("--python-preference", self.conf["uv_python_preference"]))
+        if self.conf["uv_resolution"]:
+            cmd.extend(("--resolution", self.conf["uv_resolution"]))
+        for extra in cast("set[str]", sorted(self.conf["extras"])):
+            cmd.extend(("--extra", extra))
+        if self.conf["no_default_groups"]:
+            cmd.append("--no-default-groups")
+        package = self.conf["package"]
+        if install_pkg is not None or package == "skip":
+            cmd.append("--no-install-project")
+        if self.options.verbosity > 3:  # noqa: PLR2004
+            cmd.append("-v")
+        if package in {"wheel", "uv"}:
+            cmd.extend(_no_editable_args(package_root))
+        self._add_group_args(cmd)
+        cmd.extend(self.conf["uv_sync_flags"])
+        cmd.extend(("-p", self.env_version_spec()))
+        return cmd
+
+    def _resolved_package_root(self) -> Path:
+        package_root: Path = self.conf["package_root"]
+        if not package_root.is_absolute():
+            package_root = self.core["tox_root"] / package_root
+        return package_root
+
+    def _add_lock_flags(self, cmd: list[str]) -> None:
+        uv_frozen_val = self.environment_variables.get("UV_FROZEN", "")
+        uv_frozen = uv_frozen_val.lower() not in {"", "0", "false", "no", "off"}
+        frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
+        if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
+            cmd.append("--locked")
+        if uv_frozen and not frozen_in_flags:
+            cmd.append("--frozen")
+
+    def _add_group_args(self, cmd: list[str]) -> None:
+        for group in sorted(self.conf["dependency_groups"]):
+            cmd.extend(("--group", group))
+        for group in sorted(self.conf["only_groups"]):
+            cmd.extend(("--only-group", group))
+
     @property
     def environment_variables(self) -> dict[str, str]:
         env = super().environment_variables
         env["UV_PROJECT_ENVIRONMENT"] = str(self.venv_dir)
         return env
+
+
+def _no_editable_args(package_root: Path) -> list[str]:
+    project_file = package_root / "pyproject.toml"
+    name = None
+    if project_file.exists():
+        with project_file.open("rb") as file_handler:
+            name = tomllib.load(file_handler).get("project", {}).get("name")
+    if name is None:
+        msg = "Could not detect project name"
+        raise HandledError(msg)
+    return ["--no-editable", "--reinstall-package", name]
 
 
 __all__ = [

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -93,14 +93,20 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         super()._setup_env()
         install_pkg = getattr(self.options, "install_pkg", None)
         if not getattr(self.options, "skip_uv_sync", False):
-            cmd = self._build_uv_sync_cmd(install_pkg)
-            show = self.options.verbosity > 2  # noqa: PLR2004
-            outcome = self.execute(cmd, stdin=StdinSource.OFF, run_id="uv-sync", show=show)
+            outcome = self.execute(
+                self._build_uv_sync_cmd(install_pkg),
+                stdin=StdinSource.OFF,
+                run_id="uv-sync",
+                show=self.options.verbosity > 2,  # noqa: PLR2004
+            )
             outcome.assert_success()
         if install_pkg is not None:
             path = Path(install_pkg)
-            pkg = (WheelPackage if path.suffix == ".whl" else SdistPackage)(path, deps=[])
-            self._install([pkg], "install-pkg", of_type="external")
+            self._install(
+                [(WheelPackage if path.suffix == ".whl" else SdistPackage)(path, deps=[])],
+                "install-pkg",
+                of_type="external",
+            )
 
     def _build_uv_sync_cmd(self, install_pkg: str | None) -> list[str]:
         package_root = self._resolved_package_root()
@@ -135,8 +141,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         return package_root
 
     def _add_lock_flags(self, cmd: list[str]) -> None:
-        uv_frozen_val = self.environment_variables.get("UV_FROZEN", "")
-        uv_frozen = uv_frozen_val.lower() not in {"", "0", "false", "no", "off"}
+        uv_frozen = self.environment_variables.get("UV_FROZEN", "").lower() not in {"", "0", "false", "no", "off"}
         frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
         if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
             cmd.append("--locked")

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -108,7 +108,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
             frozen_in_flags = "--frozen" in self.conf["uv_sync_flags"]
             if self.conf["uv_sync_locked"] and not uv_frozen and not frozen_in_flags:
                 cmd.append("--locked")
-            elif uv_frozen and not frozen_in_flags:
+            if uv_frozen and not frozen_in_flags:
                 cmd.append("--frozen")
             if self.conf["uv_python_preference"] != "none":
                 cmd.extend(("--python-preference", self.conf["uv_python_preference"]))

--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -89,7 +89,7 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         )
         add_skip_missing_interpreters_to_core(self.core, self.options)
 
-    def _setup_env(self) -> None:  # noqa: C901,PLR0912
+    def _setup_env(self) -> None:  # noqa: C901,PLR0912,PLR0914,PLR0915
         super()._setup_env()
         install_pkg = getattr(self.options, "install_pkg", None)
         if not getattr(self.options, "skip_uv_sync", False):

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -249,14 +249,28 @@ version = "0.1.0"
     assert "uv cannot install" in result.out
 
 
-def test_uv_resolution_env_var_change_reinstalls(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({
-        "tox.ini": """
-                [testenv]
-                deps = tomli
-                package = skip
-            """,
-    })
+@pytest.mark.parametrize(
+    ("initial_setenv", "changed_setenv", "expected_reinstall"),
+    [
+        pytest.param("", "UV_EXCLUDE_NEWER = 2024-01-01", True, id="resolution_env_var_change"),
+        pytest.param(
+            "UV_CONCURRENT_DOWNLOADS = 4", "UV_CONCURRENT_DOWNLOADS = 8", False, id="non_resolution_env_var_change"
+        ),
+    ],
+)
+def test_uv_env_var_change_reinstall(
+    tox_project: ToxProjectCreator,
+    initial_setenv: str,
+    changed_setenv: str,
+    expected_reinstall: bool,
+) -> None:
+    initial_ini = dedent(f"""
+        [testenv]
+        deps = tomli
+        package = skip
+        {"setenv = " + initial_setenv if initial_setenv else ""}
+    """)
+    project = tox_project({"tox.ini": initial_ini})
     install_count = 0
 
     def handle(r: ExecuteRequest) -> int | None:
@@ -274,54 +288,16 @@ def test_uv_resolution_env_var_change_reinstalls(tox_project: ToxProjectCreator)
     install_count = 0
 
     (project.path / "tox.ini").write_text(
-        dedent("""
-            [testenv]
-            deps = tomli
-            package = skip
-            setenv = UV_EXCLUDE_NEWER = 2024-01-01
-        """)
+        dedent(f"""
+        [testenv]
+        deps = tomli
+        package = skip
+        setenv = {changed_setenv}
+    """)
     )
     result = project.run("r")
     result.assert_success()
-    assert install_count == 1
-
-
-def test_uv_non_resolution_env_var_change_no_reinstall(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({
-        "tox.ini": """
-                [testenv]
-                deps = tomli
-                package = skip
-                setenv = UV_CONCURRENT_DOWNLOADS = 4
-            """,
-    })
-    install_count = 0
-
-    def handle(r: ExecuteRequest) -> int | None:
-        nonlocal install_count
-        if "install" in r.run_id:
-            install_count += 1
-            return 0
-        return None
-
-    project.patch_execute(handle)
-
-    result = project.run("r")
-    result.assert_success()
-    assert install_count == 1
-    install_count = 0
-
-    (project.path / "tox.ini").write_text(
-        dedent("""
-            [testenv]
-            deps = tomli
-            package = skip
-            setenv = UV_CONCURRENT_DOWNLOADS = 8
-        """)
-    )
-    result = project.run("r")
-    result.assert_success()
-    assert install_count == 0
+    assert install_count == (1 if expected_reinstall else 0)
 
 
 def test_uv_install_broken_venv(tox_project: ToxProjectCreator) -> None:

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -264,13 +264,14 @@ def test_uv_env_var_change_reinstall(
     changed_setenv: str,
     expected_reinstall: bool,
 ) -> None:
-    initial_ini = dedent(f"""
-        [testenv]
-        deps = tomli
-        package = skip
-        {"setenv = " + initial_setenv if initial_setenv else ""}
-    """)
-    project = tox_project({"tox.ini": initial_ini})
+    project = tox_project({
+        "tox.ini": dedent(f"""
+            [testenv]
+            deps = tomli
+            package = skip
+            {"setenv = " + initial_setenv if initial_setenv else ""}
+        """),
+    })
     install_count = 0
 
     def handle(r: ExecuteRequest) -> int | None:

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -406,6 +406,52 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_uv_sync_locked_suppressed_by_uv_frozen_env(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("UV_FROZEN", "1")
+    project = tox_project({
+        "tox.ini": """
+    [testenv]
+    runner = uv-venv-lock-runner
+    no_default_groups = false
+    commands = python hello
+    """
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
+    result = project.run()
+    result.assert_success()
+
+    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    uv = shutil.which("uv")
+    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
+    assert "--locked" not in uv_sync_cmd
+    assert "--frozen" in uv_sync_cmd
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_uv_sync_locked_suppressed_by_frozen_flag(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": """
+    [testenv]
+    runner = uv-venv-lock-runner
+    no_default_groups = false
+    uv_sync_flags = --frozen
+    commands = python hello
+    """
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
+    result = project.run()
+    result.assert_success()
+
+    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    uv = shutil.which("uv")
+    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
+    assert "--locked" not in uv_sync_cmd
+    assert "--frozen" in uv_sync_cmd
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_uv_sync_dependency_groups(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "tox.toml": """

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -406,15 +406,28 @@ def test_uv_sync_extra_flags_toml(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_uv_sync_locked_suppressed_by_uv_frozen_env(
-    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("uv_frozen_env", "tox_ini_extra"),
+    [
+        pytest.param("1", "", id="uv_frozen_env"),
+        pytest.param("1", "uv_sync_locked = false", id="frozen_env_with_locked_disabled"),
+        pytest.param(None, "uv_sync_flags = --frozen", id="frozen_flag"),
+    ],
+)
+def test_uv_sync_frozen_suppresses_locked(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+    uv_frozen_env: str | None,
+    tox_ini_extra: str,
 ) -> None:
-    monkeypatch.setenv("UV_FROZEN", "1")
+    if uv_frozen_env is not None:
+        monkeypatch.setenv("UV_FROZEN", uv_frozen_env)
+    extra = f"\n    {tox_ini_extra}" if tox_ini_extra else ""
     project = tox_project({
-        "tox.ini": """
+        "tox.ini": f"""
     [testenv]
     runner = uv-venv-lock-runner
-    no_default_groups = false
+    no_default_groups = false{extra}
     commands = python hello
     """
     })
@@ -423,53 +436,6 @@ def test_uv_sync_locked_suppressed_by_uv_frozen_env(
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    shutil.which("uv")
-    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
-    assert "--locked" not in uv_sync_cmd
-    assert "--frozen" in uv_sync_cmd
-
-
-@pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_uv_sync_frozen_env_with_locked_disabled(
-    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("UV_FROZEN", "1")
-    project = tox_project({
-        "tox.ini": """
-    [testenv]
-    runner = uv-venv-lock-runner
-    no_default_groups = false
-    uv_sync_locked = false
-    commands = python hello
-    """
-    })
-    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
-    result = project.run()
-    result.assert_success()
-
-    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
-    assert "--locked" not in uv_sync_cmd
-    assert "--frozen" in uv_sync_cmd
-
-
-@pytest.mark.usefixtures("clear_python_preference_env_var")
-def test_uv_sync_locked_suppressed_by_frozen_flag(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({
-        "tox.ini": """
-    [testenv]
-    runner = uv-venv-lock-runner
-    no_default_groups = false
-    uv_sync_flags = --frozen
-    commands = python hello
-    """
-    })
-    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
-    result = project.run()
-    result.assert_success()
-
-    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    shutil.which("uv")
     uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
     assert "--locked" not in uv_sync_cmd
     assert "--frozen" in uv_sync_cmd

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -422,12 +422,11 @@ def test_uv_sync_frozen_suppresses_locked(
 ) -> None:
     if uv_frozen_env is not None:
         monkeypatch.setenv("UV_FROZEN", uv_frozen_env)
-    extra = f"\n    {tox_ini_extra}" if tox_ini_extra else ""
     project = tox_project({
         "tox.ini": f"""
     [testenv]
     runner = uv-venv-lock-runner
-    no_default_groups = false{extra}
+    no_default_groups = false{f"{chr(10)}    {tox_ini_extra}" if tox_ini_extra else ""}
     commands = python hello
     """
     })
@@ -435,8 +434,7 @@ def test_uv_sync_frozen_suppresses_locked(
     result = project.run()
     result.assert_success()
 
-    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
+    uv_sync_cmd = next(i[0][3].cmd for i in execute_calls.call_args_list if i[0][3].run_id == "uv-sync")
     assert "--locked" not in uv_sync_cmd
     assert "--frozen" in uv_sync_cmd
 

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -423,7 +423,7 @@ def test_uv_sync_locked_suppressed_by_uv_frozen_env(
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = shutil.which("uv")
+    shutil.which("uv")
     uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
     assert "--locked" not in uv_sync_cmd
     assert "--frozen" in uv_sync_cmd
@@ -445,7 +445,7 @@ def test_uv_sync_locked_suppressed_by_frozen_flag(tox_project: ToxProjectCreator
     result.assert_success()
 
     calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
-    uv = shutil.which("uv")
+    shutil.which("uv")
     uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
     assert "--locked" not in uv_sync_cmd
     assert "--frozen" in uv_sync_cmd

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -430,6 +430,30 @@ def test_uv_sync_locked_suppressed_by_uv_frozen_env(
 
 
 @pytest.mark.usefixtures("clear_python_preference_env_var")
+def test_uv_sync_frozen_env_with_locked_disabled(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("UV_FROZEN", "1")
+    project = tox_project({
+        "tox.ini": """
+    [testenv]
+    runner = uv-venv-lock-runner
+    no_default_groups = false
+    uv_sync_locked = false
+    commands = python hello
+    """
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
+    result = project.run()
+    result.assert_success()
+
+    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    uv_sync_cmd = next(cmd for _, run_id, cmd in calls if run_id == "uv-sync")
+    assert "--locked" not in uv_sync_cmd
+    assert "--frozen" in uv_sync_cmd
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
 def test_uv_sync_locked_suppressed_by_frozen_flag(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "tox.ini": """


### PR DESCRIPTION
## Summary

Fixes #326.

When `UV_FROZEN` is set in the environment (a common CI pattern), `uv-venv-lock-runner` previously still appended `--locked` to the `uv sync` command. Since `--locked` and `--frozen` are mutually exclusive in uv, this caused an immediate failure:

```
error: the argument `--locked` cannot be used with `UV_FROZEN` (environment variable)
```

The same conflict occurs when a user adds `--frozen` to `uv_sync_flags` without also setting `uv_sync_locked = false`.

### Changes

- Suppress `--locked` when `UV_FROZEN` is truthy in the environment
- Explicitly add `--frozen` to the `uv sync` command in that case, so it is visible in logs
- Suppress `--locked` when `--frozen` is already present in `uv_sync_flags`

### Behaviour after this fix

| Configuration | Command |
|---|---|
| default | `uv sync --locked ...` |
| `UV_FROZEN=1` in env | `uv sync --frozen ...` |
| `uv_sync_flags = --frozen` | `uv sync --frozen ...` |
| `uv_sync_locked = false` | `uv sync ...` |
| `uv_sync_locked = false` + `UV_FROZEN=1` | `uv sync --frozen ...` |

### Note on `-x` override for pyproject.toml users

Issue #326 also reports that `-x testenv.uv_sync_locked=false` does not work. Investigation shows this is specific to `pyproject.toml` native TOML format: tox's TOML source uses `.` as the section separator, so the correct override syntax is `-x tool.tox.env_run_base.uv_sync_locked=false`. This is a tox-core behaviour and is not addressed here.

## Test plan

- Three new unit tests added:
  - `test_uv_sync_locked_suppressed_by_uv_frozen_env` — asserts `--frozen` appears and `--locked` does not when `UV_FROZEN=1` is set
  - `test_uv_sync_frozen_env_with_locked_disabled` — asserts `--frozen` still appears explicitly when `UV_FROZEN=1` and `uv_sync_locked = false`
  - `test_uv_sync_locked_suppressed_by_frozen_flag` — asserts `--locked` is absent when `--frozen` is in `uv_sync_flags`

- Tested locally against a real project with `UV_FROZEN=1 .venv/bin/tox`, confirming `uv sync --frozen ...` appears in output and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)