### PR TITLE
Honor constraints opt for all packages

### DIFF
--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -183,7 +183,8 @@ class UvInstaller(Pip):
         req_of_type = f"{of_type}_deps" if groups["pkg"] or groups["dev_pkg"] else of_type
         for value in groups.values():
             value.sort()
-        cache_value = {"req": groups["req"], "env": self._install_env_vars()}
+        constraint_args = self.constraints.as_root_args
+        cache_value = {"req": groups["req"], "env": self._install_env_vars(), "constraints": constraint_args}
         with self._env.cache.compare(cache_value, section, req_of_type) as (eq, old):
             if not eq:  # pragma: no branch
                 old_req: list[str] = old["req"] if isinstance(old, dict) else (old or [])
@@ -193,13 +194,14 @@ class UvInstaller(Pip):
                     raise Recreate(msg)  # pragma: no cover
                 new_deps = sorted(set(groups["req"]) - set(old_req)) or list(groups["req"])
                 if new_deps:  # pragma: no branch
+                    new_deps.extend(constraint_args)
                     self._execute_installer(new_deps, req_of_type)
         install_args = ["--reinstall"]
         if groups["uv"]:
-            self._execute_installer(install_args + groups["uv"], of_type)
+            self._execute_installer(install_args + groups["uv"] + constraint_args, of_type)
         if groups["uv_editable"]:
             requirements = list(chain.from_iterable(("-e", entry) for entry in groups["uv_editable"]))
-            self._execute_installer(install_args + requirements, of_type)
+            self._execute_installer(install_args + requirements + constraint_args, of_type)
         install_args.append("--no-deps")
         if groups["pkg"]:
             self._execute_installer(install_args + groups["pkg"], of_type)

--- a/tests/test_tox_uv_installer.py
+++ b/tests/test_tox_uv_installer.py
@@ -330,3 +330,34 @@ def test_uv_install_broken_venv(tox_project: ToxProjectCreator) -> None:
     result = project.run("run", "-v")
     result.assert_success()
     assert "recreate env because existing venv is broken" in result.out
+
+
+def test_uv_install_with_constraints_for_deps(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.ini": dedent("""
+            [testenv]
+            package = skip
+            dependency_groups = test
+            constraints = constraints.txt
+        """),
+        "pyproject.toml": dedent("""
+            [project]
+            name = "test-pkg"
+            version = "0.1.0"
+
+            [dependency-groups]
+            test = ["pytest>=8.0.0"]
+        """),
+        "constraints.txt": "pytest==8.3.0\n",
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+
+    result = project.run("-vv")
+    result.assert_success()
+
+    install_calls = [call[0][3].cmd for call in execute_calls.call_args_list if "install" in call[0][3].run_id]
+    assert len(install_calls) == 1
+    cmd = install_calls[0][2:]  # skip uv binary and "pip"
+    assert cmd[0] == "install"
+    assert "pytest>=8.0.0" in cmd
+    assert "-c" in cmd


### PR DESCRIPTION
Ensure that any constraints file(s) specified in `tox.toml` / `tox.ini` are respected during install and form part of the cache.

Closes #330.
