### PR TITLE
🐛 fix(lock): honor --recreate in uv-venv-lock-runner

### DIFF
--- a/src/tox_uv/_run_lock.py
+++ b/src/tox_uv/_run_lock.py
@@ -125,6 +125,8 @@ class UvVenvLockRunner(UvVenv, RunToxEnv):
         package = self.conf["package"]
         if install_pkg is not None or package == "skip":
             cmd.append("--no-install-project")
+        if self.conf["recreate"] and "--reinstall" not in self.conf["uv_sync_flags"]:
+            cmd.append("--reinstall")
         if self.options.verbosity > 3:  # noqa: PLR2004
             cmd.append("-v")
         if package in {"wheel", "uv"}:

--- a/tests/test_tox_uv_lock.py
+++ b/tests/test_tox_uv_lock.py
@@ -882,3 +882,31 @@ commands = [["python", "hello"]]
         ("py", "commands[0]", ["python", "hello"]),
     ]
     assert calls == expected
+
+
+@pytest.mark.usefixtures("clear_python_preference_env_var")
+@pytest.mark.parametrize(
+    ("extra_tox_ini", "run_args", "expected_count"),
+    [
+        pytest.param("", ("--recreate",), 1, id="recreate-adds-reinstall"),
+        pytest.param("uv_sync_flags = --reinstall", ("--recreate",), 1, id="recreate-skips-when-user-set"),
+        pytest.param("", (), 0, id="no-recreate-omits-reinstall"),
+    ],
+)
+def test_uv_lock_recreate_reinstall(
+    tox_project: ToxProjectCreator, extra_tox_ini: str, run_args: tuple[str, ...], expected_count: int
+) -> None:
+    project = tox_project({
+        "tox.ini": f"""
+    [testenv]
+    runner = uv-venv-lock-runner
+    {extra_tox_ini}
+    """
+    })
+    execute_calls = project.patch_execute(lambda r: 0 if r.run_id != "venv" else None)
+    result = project.run("run", "--notest", *run_args)
+    result.assert_success()
+
+    calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    uv_sync_call = next(c for c in calls if c[1] == "uv-sync")
+    assert uv_sync_call[2].count("--reinstall") == expected_count


### PR DESCRIPTION
Running `tox --recreate` with `uv-venv-lock-runner` deleted the venv but left the project install untouched, because `uv sync` happily reused its cached project wheel. Packages with C extensions ended up serving stale binaries even though the user explicitly asked for a clean rebuild.

The runner now appends `--reinstall` to `uv sync` whenever `recreate` is set on the env. `--reinstall` implies `--refresh`, so uv drops the cached wheel and re-runs the build backend, which gives the C extensions a chance to recompile. The flag is suppressed if the user already passes `--reinstall` through `uv_sync_flags` so it does not appear twice on the command line.

Existing runs without `--recreate` are unaffected. Fixes #336.