### PR TITLE
🐛 fix(installer): align with tox 4.59 API changes

### DIFF
--- a/src/tox_uv/_installer.py
+++ b/src/tox_uv/_installer.py
@@ -26,7 +26,7 @@ from ._package_types import UvEditablePackage, UvPackage
 
 if TYPE_CHECKING:
     from tox.config.main import Config
-    from tox.tox_env.package import PathPackage
+    from tox.tox_env.package import Package
 
     from ._venv import UvVenv
 
@@ -145,9 +145,7 @@ class UvInstaller(Pip):
 
     def _install_list_of_deps(  # ruff:ignore[complex-structure, too-many-branches]
         self,
-        arguments: Sequence[
-            Requirement | WheelPackage | SdistPackage | EditableLegacyPackage | EditablePackage | PathPackage
-        ],
+        arguments: Sequence[Requirement | Package],
         section: str,
         of_type: str,
     ) -> None:

--- a/src/tox_uv/_venv.py
+++ b/src/tox_uv/_venv.py
@@ -81,7 +81,7 @@ class UvVenv(Python, ABC):
                 return value.lower()
             return "system"
 
-        self.conf.add_config(  # ty: ignore[no-matching-overload]
+        self.conf.add_config(
             keys=["uv_python_preference"],
             of_type=cast("type[PythonPreference | None]", PythonPreference | None),
             # use os.environ here instead of self.environment_variables as this value is needed to create the virtual

--- a/tests/test_tox_uv_venv.py
+++ b/tests/test_tox_uv_venv.py
@@ -579,11 +579,9 @@ def test_get_python_free_threaded(base_python: str, is_free_threaded: int | None
 
 @pytest.mark.parametrize("env_name", ["pypy", "cpython"])
 def test_get_python_abs_path_with_impl(env_name: str) -> None:
-    create_args = mock.Mock()
-    create_args.conf = mock.MagicMock()
-    create_args.conf.__getitem__.return_value = env_name
-    uv_venv = _TestUvVenv(create_args=create_args)
-    python_info = uv_venv.get_python_info(sys.executable)
+    uv_venv = _TestUvVenv(create_args=mock.Mock())
+    with mock.patch.object(type(uv_venv), "name", new_callable=mock.PropertyMock, return_value=env_name):
+        python_info = uv_venv.get_python_info(sys.executable)
     assert python_info is not None
     expected_impl = "CPython" if env_name == "cpython" else env_name
     assert python_info.implementation.lower() == expected_impl.lower()


### PR DESCRIPTION
The scheduled check has been red since tox 4.59 landed (https://github.com/tox-dev/tox-uv/actions/runs/31787082911): tox-dev/tox@7be33b8 widened `Pip._install_list_of_deps` to `Sequence[Requirement | Package]`, so ty reports the narrower override in `_installer.py` as incompatible, and `ToxEnv.name` now reads `conf.get("env_name", str)`, so `test_get_python_abs_path_with_impl` priming only `conf.__getitem__` hands a MagicMock to `PythonSpec.from_string_spec`. Widen the override to `Package`, drop the `ty: ignore[no-matching-overload]` that ty now flags as unused, and patch `name` with a PropertyMock in the test the same way its neighbour does, so it stays independent of how tox resolves the env name.